### PR TITLE
@axflow/models: support for HuggingFace text-generation tasks

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
                     text: 'AnthropicCompletion',
                     link: '/documentation/models/anthropic-completion',
                   },
+                  {
+                    text: 'HuggingFaceTextGeneration',
+                    link: '/documentation/models/huggingface-text-generation',
+                  },
                   { text: 'CohereGeneration', link: '/documentation/models/cohere-generation' },
                   { text: 'CohereEmbedding', link: '/documentation/models/cohere-embedding' },
                   { text: 'React', link: '/documentation/models/react' },

--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -12,7 +12,7 @@ npm i @axflow/models
 - First-class support for streaming arbitrary data in addition to the LLM response
 - Comes with a set of utilities and React hooks for easily creating robust client applications
 - Built exclusively on modern web standards such as `fetch` and the stream APIs
-- Supports Node 18+, Next.js serverless or edge runtime, browsers, ESM, CJS, and more
+- Supports Node 18+, Next.js serverless or edge runtime, Express.js, browsers, ESM, CJS, and more
 - Supports a custom `fetch` implementation for request middleware (e.g., custom headers, logging)
 
 ## Supported models

--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -20,7 +20,7 @@ npm i @axflow/models
 - ✅ OpenAI and OpenAI-compatible Chat, Completion, and Embedding models
 - ✅ Cohere and Cohere-compatible Generation and Embedding models
 - ✅ Anthropic and Anthropic-compatible Completion models
-- ✅ HuggingFace inference API
+- ✅ HuggingFace inference API or Inference Endpoints
 - Google PaLM models (coming soon)
 - Azure OpenAI (coming soon)
 - Replicate (coming soon)

--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -8,43 +8,44 @@ npm i @axflow/models
 
 ## Features
 
-* First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
-* First-class support for streaming arbitrary data in addition to the LLM response
-* Comes with a set of utilities and React hooks for easily creating robust client applications
-* Built exclusively on modern web standards such as `fetch` and the stream APIs
-* Supports Node 18+, Next.js serverless or edge runtime, Express.js, browsers, ESM, CJS, and more
-* Supports a custom `fetch` implementation for request middleware (e.g., custom headers, logging)
+- First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
+- First-class support for streaming arbitrary data in addition to the LLM response
+- Comes with a set of utilities and React hooks for easily creating robust client applications
+- Built exclusively on modern web standards such as `fetch` and the stream APIs
+- Supports Node 18+, Next.js serverless or edge runtime, browsers, ESM, CJS, and more
+- Supports a custom `fetch` implementation for request middleware (e.g., custom headers, logging)
 
 ## Supported models
 
 - ✅ OpenAI and OpenAI-compatible Chat, Completion, and Embedding models
 - ✅ Cohere and Cohere-compatible Generation and Embedding models
 - ✅ Anthropic and Anthropic-compatible Completion models
+- ✅ HuggingFace inference API
 - Google PaLM models (coming soon)
 - Azure OpenAI (coming soon)
 - Replicate (coming soon)
-- HuggingFace (coming soon)
 
 ## Documentation
 
 View the [Guides](/guides) or the reference:
 
-* [@axflow/models/openai/chat](/documentation/models/openai-chat)
-* [@axflow/models/openai/completion](/documentation/models/openai-completion)
-* [@axflow/models/openai/embedding](/documentation/models/openai-embedding)
-* [@axflow/models/anthropic/completion](/documentation/models/anthropic-completion)
-* [@axflow/models/cohere/generation](/documentation/models/cohere-generation)
-* [@axflow/models/cohere/embedding](/documentation/models/cohere-embedding)
-* [@axflow/models/react](/documentation/models/react)
-* [@axflow/models/node](/documentation/models/node)
-* [@axflow/models/shared](/documentation/models/shared)
+- [@axflow/models/openai/chat](/documentation/models/openai-chat)
+- [@axflow/models/openai/completion](/documentation/models/openai-completion)
+- [@axflow/models/openai/embedding](/documentation/models/openai-embedding)
+- [@axflow/models/anthropic/completion](/documentation/models/anthropic-completion)
+- [@axflow/models/cohere/generation](/documentation/models/cohere-generation)
+- [@axflow/models/cohere/embedding](/documentation/models/cohere-embedding)
+- [@axflow/models/huggingface/text-generation](/documentation/models/huggingface-text-generation)
+- [@axflow/models/react](/documentation/models/react)
+- [@axflow/models/node](/documentation/models/node)
+- # [@axflow/models/shared](/documentation/models/shared)
 
 ## Example Usage
 
 ```ts
-import {OpenAIChat} from '@axflow/models/openai/chat';
-import {CohereGenerate} from '@axflow/models/cohere/generate';
-import {StreamToIterable} from '@axflow/models/shared';
+import { OpenAIChat } from '@axflow/models/openai/chat';
+import { CohereGenerate } from '@axflow/models/cohere/generate';
+import { StreamToIterable } from '@axflow/models/shared';
 
 const gpt4Stream = OpenAIChat.stream(
   {
@@ -53,7 +54,7 @@ const gpt4Stream = OpenAIChat.stream(
   },
   {
     apiKey: '<openai api key>',
-  },
+  }
 );
 
 const cohereStream = CohereGenerate.stream(
@@ -63,7 +64,7 @@ const cohereStream = CohereGenerate.stream(
   },
   {
     apiKey: '<cohere api key>',
-  },
+  }
 );
 
 // StreamToIterable is optional in recent node versions as
@@ -80,7 +81,7 @@ for await (const chunk of StreamToIterable(cohereStream)) {
 For models that support streaming, there is a convenience method for streaming only the string tokens.
 
 ```ts
-import {OpenAIChat} from '@axflow/models/openai/chat';
+import { OpenAIChat } from '@axflow/models/openai/chat';
 
 const tokenStream = OpenAIChat.streamTokens(
   {
@@ -89,7 +90,7 @@ const tokenStream = OpenAIChat.streamTokens(
   },
   {
     apiKey: '<openai api key>',
-  },
+  }
 );
 
 // Example stdout output:
@@ -100,7 +101,7 @@ for await (const token of tokenStream) {
   process.stdout.write(token);
 }
 
-process.stdout.write("\n");
+process.stdout.write('\n');
 ```
 
 ## `useChat` hook for dead simple UI integration
@@ -126,7 +127,7 @@ export async function POST(request: Request) {
     },
     {
       apiKey: process.env.OPENAI_API_KEY!,
-    },
+    }
   );
 
   return new StreamingJsonResponse(stream);
@@ -138,7 +139,7 @@ export async function POST(request: Request) {
 import { useChat } from '@axflow/models/react';
 
 function ChatComponent() {
-  const {input, messages, onChange, onSubmit} = useChat();
+  const { input, messages, onChange, onSubmit } = useChat();
 
   return (
     <>
@@ -153,13 +154,13 @@ function ChatComponent() {
 
 Sometimes you just want to create a proxy to the underlying LLM API. In this example, the server intercepts the request on the edge, adds the proper API key, and forwards the byte stream back to the client.
 
-*Note this pattern works exactly the same with our other models that support streaming, like Cohere and Anthropic.*
+_Note this pattern works exactly the same with our other models that support streaming, like Cohere and Anthropic._
 
 ```ts
 import { NextRequest, NextResponse } from 'next/server';
 import { OpenAIChat } from '@axflow/models/openai/chat';
 
-export const runtime = 'edge'
+export const runtime = 'edge';
 
 // POST /api/openai/chat
 export async function POST(request: NextRequest) {
@@ -176,7 +177,7 @@ export async function POST(request: NextRequest) {
 
 On the client, we can use `OpenAIChat.stream` with a custom `apiUrl` in place of the `apiKey` that points to our Next.js edge route.
 
-*DO NOT expose api keys to your frontend.*
+_DO NOT expose api keys to your frontend._
 
 ```ts
 import { OpenAIChat } from '@axflow/models/openai/chat';
@@ -188,7 +189,7 @@ const stream = await OpenAIChat.stream(
     messages: [{ role: 'user', content: 'What is the Eiffel tower?' }],
   },
   {
-    apiUrl: "/api/openai/chat",
+    apiUrl: '/api/openai/chat',
   }
 );
 
@@ -205,19 +206,19 @@ Uses express + React hook on frontend.
 ///////////////////
 // On the server //
 ///////////////////
-const express = require("express");
-const { OpenAIChat } = require("@axflow/models/openai/chat");
-const { streamJsonResponse } = require("@axflow/models/node");
+const express = require('express');
+const { OpenAIChat } = require('@axflow/models/openai/chat');
+const { streamJsonResponse } = require('@axflow/models/node');
 
 const app = express();
 app.use(express.json());
 
-app.post("/api/chat", async (req, res) => {
+app.post('/api/chat', async (req, res) => {
   const { messages } = req.body;
 
   const stream = await OpenAIChat.streamTokens(
     {
-      model: "gpt-3.5-turbo",
+      model: 'gpt-3.5-turbo',
       messages: messages.map((msg) => ({
         role: msg.role,
         content: msg.content,
@@ -235,14 +236,13 @@ app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });
 
-
 ///////////////////
 // On the client //
 ///////////////////
 import { useChat } from '@axflow/models/react';
 
 function ChatComponent() {
-  const {input, messages, onChange, onSubmit} = useChat();
+  const { input, messages, onChange, onSubmit } = useChat();
 
   return (
     <>
@@ -251,3 +251,4 @@ function ChatComponent() {
     </>
   );
 }
+```

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -3,12 +3,12 @@
 Interface with [HuggingFace's Inference API](https://huggingface.co/docs/api-inference/quicktour) using this module.
 
 ```ts
-import { HuggingFaceGeneration } from '@axflow/models/huggingface/text-generation';
+import { HuggingFaceTextGeneration } from '@axflow/models/huggingface/text-generation';
 import type { HuggingFaceTextGenerationTypes } from '@axflow/models/huggingface/text-generation';
 ```
 
 ```ts
-declare class HuggingFaceGeneration {
+declare class HuggingFaceTextGeneration {
   static run: typeof run;
   static stream: typeof stream;
   static streamBytes: typeof streamBytes;
@@ -91,6 +91,7 @@ declare function stream(
 ```ts
 /**
  * Run a streaming completion against the HF inference API. The resulting stream emits only the string tokens.
+ * Note that this will strip the STOP token '</s>' from the text.
  *
  * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
  *
@@ -110,10 +111,10 @@ declare function streamTokens(
 ## Using Inference Endpoints
 
 You might have hosted your own model through HuggingFace's Inference Endpoints product.
-This is perfectly compatible with axflow's huggingface library, simply pass in the inference URL to the `HuggingFaceGeneration` request with the `apiUrl` parameter, like below:
+This is perfectly compatible with axflow's huggingface library, simply pass in the inference URL to the `HuggingFaceTextGeneration` request with the `apiUrl` parameter, like below:
 
 ```ts
-const response = await HuggingFaceGeneration.stream(
+const response = await HuggingFaceTextGeneration.stream(
   {
     model: 'llama2-7b',
     inputs: 'Write a typescript function to add two numbers',

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -1,0 +1,108 @@
+# @axflow/models/huggingface/generation
+
+Interface with [HuggingFace's Inference API](https://huggingface.co/docs/api-inference/quicktour) using this module.
+
+```ts
+import { HuggingFaceGeneration } from '@axflow/models/huggingface/text-generation';
+import type { HuggingFaceTextGenerationTypes } from '@axflow/models/huggingface/text-generation';
+```
+
+```ts
+declare class HuggingFaceGeneration {
+  static run: typeof run;
+  static stream: typeof stream;
+  static streamBytes: typeof streamBytes;
+  static streamTokens: typeof streamTokens;
+}
+```
+
+## `run`
+
+```ts
+/**
+ * Run a textGeneration task against the HF inference API
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns The response body from HF. See their documentation linked above for details
+ */
+declare function run(
+  request: HuggingFaceTextGenerationTypes.Request,
+  options: HuggingFaceTextGenerationTypes.RequestOptions
+): Promise<HuggingFaceTextGenerationTypes.Response>;
+```
+
+## `streamBytes`
+
+```ts
+/**
+ * Stream a textGeneration task against the HF inference API. The resulting stream is the raw unmodified bytes from the API
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of bytes directly from the API.
+ */
+declare function streamBytes(
+  request: HuggingFaceTextGenerationTypes.Request,
+  options: HuggingFaceTextGenerationTypes.RequestOptions
+): Promise<ReadableStream<Uint8Array>>;
+```
+
+## `stream`
+
+```ts
+/**
+ * Stream a textGeneration task against the HF inference API. The resulting stream is the parsed stream data as JavaScript objects.
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of objects representing each chunk from the API
+ *
+ *   Example chunk:
+ *     {
+ *       token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
+ *       generated_text: null,
+ *       details: null
+ *     }
+ */
+declare function stream(
+  request: HuggingFaceTextGenerationTypes.Request,
+  options: HuggingFaceTextGenerationTypes.RequestOptions
+): Promise<ReadableStream<HuggingFaceTextGenerationTypes.Chunk>>;
+```
+
+## `streamTokens`
+
+```ts
+/**
+ * Run a streaming completion against the HF inference API. The resulting stream emits only the string tokens.
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of tokens from the API.
+ */
+declare function streamTokens(
+  request: HuggingFaceTextGenerationTypes.Request,
+  options: HuggingFaceTextGenerationTypes.RequestOptions
+): Promise<ReadableStream<string>>;
+```

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -29,6 +29,7 @@ declare class HuggingFaceTextGeneration {
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns The response body from HF. See their documentation linked above for details
  */
 declare function run(
@@ -50,6 +51,7 @@ declare function run(
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -71,6 +73,7 @@ declare function streamBytes(
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API
  *
  *   Example chunk:
@@ -100,6 +103,7 @@ declare function stream(
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -65,6 +65,12 @@ declare function streamBytes(
 ```ts
 /**
  * Stream a textGeneration task against the HF inference API. The resulting stream is the parsed stream data as JavaScript objects.
+ * Example chunk:
+ *   {
+ *     token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
+ *     generated_text: null,
+ *     details: null
+ *   }
  *
  * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
  *
@@ -75,13 +81,6 @@ declare function streamBytes(
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API
- *
- *   Example chunk:
- *     {
- *       token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
- *       generated_text: null,
- *       details: null
- *     }
  */
 declare function stream(
   request: HuggingFaceTextGenerationTypes.Request,

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -106,3 +106,24 @@ declare function streamTokens(
   options: HuggingFaceTextGenerationTypes.RequestOptions
 ): Promise<ReadableStream<string>>;
 ```
+
+## Using Inference Endpoints
+
+You might have hosted your own model through HuggingFace's Inference Endpoints product.
+This is perfectly compatible with axflow's huggingface library, simply pass in the inference URL to the `HuggingFaceGeneration` request with the `apiUrl` parameter, like below:
+
+```ts
+const response = await HuggingFaceGeneration.stream(
+  {
+    model: 'llama2-7b',
+    inputs: 'Write a typescript function to add two numbers',
+    parameters: {
+      max_new_tokens: 100,
+    },
+  },
+  {
+    accessToken: process.env.HF_TOKEN!,
+    apiUrl: 'https://styuqm054heenl9w.us-east-1.aws.endpoints.huggingface.cloud',
+  }
+);
+```

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -8,12 +8,12 @@ npm i @axflow/models
 
 ## Features
 
-* First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
-* First-class support for streaming arbitrary data in addition to the LLM response
-* Comes with a set of utilities and React hooks for easily creating robust client applications
-* Built exclusively on modern web standards such as `fetch` and the stream APIs
-* Supports Node 18+, Next.js serverless or edge runtime, Express.js, browsers, ESM, CJS, and more
-* Supports a custom `fetch` implementation for request middleware (e.g., custom headers, logging)
+- First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
+- First-class support for streaming arbitrary data in addition to the LLM response
+- Comes with a set of utilities and React hooks for easily creating robust client applications
+- Built exclusively on modern web standards such as `fetch` and the stream APIs
+- Supports Node 18+, Next.js serverless or edge runtime, Express.js, browsers, ESM, CJS, and more
+- Supports a custom `fetch` implementation for request middleware (e.g., custom headers, logging)
 
 ## Supported models
 
@@ -29,22 +29,22 @@ npm i @axflow/models
 
 View the [Guides](https://docs.axflow.dev/guides) or the reference:
 
-* [@axflow/models/openai/chat](https://docs.axflow.dev/documentation/models/openai-chat.html)
-* [@axflow/models/openai/completion](https://docs.axflow.dev/documentation/models/openai-completion.html)
-* [@axflow/models/openai/embedding](https://docs.axflow.dev/documentation/models/openai-embedding.html)
-* [@axflow/models/anthropic/completion](https://docs.axflow.dev/documentation/models/anthropic-completion.html)
-* [@axflow/models/cohere/generation](https://docs.axflow.dev/documentation/models/cohere-generation.html)
-* [@axflow/models/cohere/embedding](https://docs.axflow.dev/documentation/models/cohere-embedding.html)
-* [@axflow/models/react](https://docs.axflow.dev/documentation/models/react.html)
-* [@axflow/models/node](https://docs.axflow.dev/documentation/models/node.html)
-* [@axflow/models/shared](https://docs.axflow.dev/documentation/models/shared.html)
+- [@axflow/models/openai/chat](https://docs.axflow.dev/documentation/models/openai-chat.html)
+- [@axflow/models/openai/completion](https://docs.axflow.dev/documentation/models/openai-completion.html)
+- [@axflow/models/openai/embedding](https://docs.axflow.dev/documentation/models/openai-embedding.html)
+- [@axflow/models/anthropic/completion](https://docs.axflow.dev/documentation/models/anthropic-completion.html)
+- [@axflow/models/cohere/generation](https://docs.axflow.dev/documentation/models/cohere-generation.html)
+- [@axflow/models/cohere/embedding](https://docs.axflow.dev/documentation/models/cohere-embedding.html)
+- [@axflow/models/react](https://docs.axflow.dev/documentation/models/react.html)
+- [@axflow/models/node](https://docs.axflow.dev/documentation/models/node.html)
+- [@axflow/models/shared](https://docs.axflow.dev/documentation/models/shared.html)
 
 ## Example Usage
 
 ```ts
-import {OpenAIChat} from '@axflow/models/openai/chat';
-import {CohereGenerate} from '@axflow/models/cohere/generate';
-import {StreamToIterable} from '@axflow/models/shared';
+import { OpenAIChat } from '@axflow/models/openai/chat';
+import { CohereGenerate } from '@axflow/models/cohere/generate';
+import { StreamToIterable } from '@axflow/models/shared';
 
 const gpt4Stream = OpenAIChat.stream(
   {
@@ -80,7 +80,7 @@ for await (const chunk of StreamToIterable(cohereStream)) {
 For models that support streaming, there is a convenience method for streaming only the string tokens.
 
 ```ts
-import {OpenAIChat} from '@axflow/models/openai/chat';
+import { OpenAIChat } from '@axflow/models/openai/chat';
 
 const tokenStream = OpenAIChat.streamTokens(
   {
@@ -100,7 +100,7 @@ for await (const token of tokenStream) {
   process.stdout.write(token);
 }
 
-process.stdout.write("\n");
+process.stdout.write('\n');
 ```
 
 ## `useChat` hook for dead simple UI integration
@@ -138,7 +138,7 @@ export async function POST(request: Request) {
 import { useChat } from '@axflow/models/react';
 
 function ChatComponent() {
-  const {input, messages, onChange, onSubmit} = useChat();
+  const { input, messages, onChange, onSubmit } = useChat();
 
   return (
     <>
@@ -153,13 +153,13 @@ function ChatComponent() {
 
 Sometimes you just want to create a proxy to the underlying LLM API. In this example, the server intercepts the request on the edge, adds the proper API key, and forwards the byte stream back to the client.
 
-*Note this pattern works exactly the same with our other models that support streaming, like Cohere and Anthropic.*
+_Note this pattern works exactly the same with our other models that support streaming, like Cohere and Anthropic._
 
 ```ts
 import { NextRequest, NextResponse } from 'next/server';
 import { OpenAIChat } from '@axflow/models/openai/chat';
 
-export const runtime = 'edge'
+export const runtime = 'edge';
 
 // POST /api/openai/chat
 export async function POST(request: NextRequest) {
@@ -176,7 +176,7 @@ export async function POST(request: NextRequest) {
 
 On the client, we can use `OpenAIChat.stream` with a custom `apiUrl` in place of the `apiKey` that points to our Next.js edge route.
 
-*DO NOT expose api keys to your frontend.*
+_DO NOT expose api keys to your frontend._
 
 ```ts
 import { OpenAIChat } from '@axflow/models/openai/chat';
@@ -188,8 +188,8 @@ const stream = await OpenAIChat.stream(
     messages: [{ role: 'user', content: 'What is the Eiffel tower?' }],
   },
   {
-    apiUrl: "/api/openai/chat",
-  }
+    apiUrl: '/api/openai/chat',
+  },
 );
 
 for await (const chunk of StreamToIterable(stream)) {
@@ -205,19 +205,19 @@ Uses express + React hook on frontend.
 ///////////////////
 // On the server //
 ///////////////////
-const express = require("express");
-const { OpenAIChat } = require("@axflow/models/openai/chat");
-const { streamJsonResponse } = require("@axflow/models/node");
+const express = require('express');
+const { OpenAIChat } = require('@axflow/models/openai/chat');
+const { streamJsonResponse } = require('@axflow/models/node');
 
 const app = express();
 app.use(express.json());
 
-app.post("/api/chat", async (req, res) => {
+app.post('/api/chat', async (req, res) => {
   const { messages } = req.body;
 
   const stream = await OpenAIChat.streamTokens(
     {
-      model: "gpt-3.5-turbo",
+      model: 'gpt-3.5-turbo',
       messages: messages.map((msg) => ({
         role: msg.role,
         content: msg.content,
@@ -225,7 +225,7 @@ app.post("/api/chat", async (req, res) => {
     },
     {
       apiKey: process.env.OPENAI_API_KEY,
-    }
+    },
   );
 
   return streamJsonResponse(stream, res);
@@ -235,14 +235,13 @@ app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });
 
-
 ///////////////////
 // On the client //
 ///////////////////
 import { useChat } from '@axflow/models/react';
 
 function ChatComponent() {
-  const {input, messages, onChange, onSubmit} = useChat();
+  const { input, messages, onChange, onSubmit } = useChat();
 
   return (
     <>

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -144,9 +144,9 @@
     },
     "./huggingface/text-generation": {
       "types": "./dist/huggingface/text-generation.d.ts",
-      "import": "./dist/huggingface/text-generationembedding.mjs",
-      "module": "./dist/huggingface/text-generationembedding.mjs",
-      "require": "./dist/huggingface/text-generationembedding.js"
+      "import": "./dist/huggingface/text-generation.mjs",
+      "module": "./dist/huggingface/text-generation.mjs",
+      "require": "./dist/huggingface/text-generation.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -23,7 +23,9 @@
     "models",
     "useChat",
     "nextjs",
-    "react"
+    "react",
+    "hugging face",
+    "huggingface"
   ],
   "files": [
     "dist/**/*"
@@ -94,6 +96,9 @@
       "node": [
         "./dist/node/index.d.ts"
       ],
+      "huggingface": [
+        "./dist/huggingface/index.d.ts"
+      ],
       "shared": [
         "./dist/shared/index.d.ts"
       ]
@@ -136,6 +141,12 @@
       "import": "./dist/cohere/embedding.mjs",
       "module": "./dist/cohere/embedding.mjs",
       "require": "./dist/cohere/embedding.js"
+    },
+    "./huggingface/text-generation": {
+      "types": "./dist/huggingface/text-generation.d.ts",
+      "import": "./dist/huggingface/text-generationembedding.mjs",
+      "module": "./dist/huggingface/text-generationembedding.mjs",
+      "require": "./dist/huggingface/text-generationembedding.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -1,0 +1,77 @@
+import { POST } from '@axflow/models/utils';
+
+// With Hugging Face, we need to first choose a "task" and then pick a compatible model.
+// The tasks we are using (for llama2 for instance): 'text-generation'
+// https://huggingface.co/models?pipeline_tag=conversational
+
+// https://huggingface.co/docs/api-inference/quicktour#running-inference-with-api-requests
+const HF_MODEL_API_URL = 'https://api-inference.huggingface.co/models/';
+const SUPPORTED_MODELS = ['gpt2'];
+
+function headers(accessToken?: string) {
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+  };
+  if (typeof accessToken === 'string') {
+    headers.authorization = `Bearer ${accessToken}`;
+  }
+  return headers;
+}
+
+export namespace HfChatTypes {
+  // https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+  export type Request = {
+    model: string;
+    inputs: string;
+    parameters: {
+      top_k?: number;
+      top_p?: number;
+      // Float range from 0.00 to 100.00. Default is 1.0
+      temperature: number;
+      repetition_penalty?: number;
+      max_new_tokens?: number;
+      // In seconds
+      max_time?: number;
+      return_full_text?: boolean;
+      num_return_sequences?: number;
+      do_sample?: boolean;
+    };
+    options: {
+      use_cache?: boolean;
+      wait_for_model?: boolean;
+    };
+  };
+
+  export type RequestOptions = {
+    accessToken?: string;
+    apiUrl?: string;
+    fetch?: typeof fetch;
+  };
+
+  export type GeneratedText = {
+    generated_text: string;
+  };
+  // https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+  export type Response = GeneratedText | GeneratedText[];
+}
+
+async function run(
+  request: HfChatTypes.Request,
+  options: HfChatTypes.RequestOptions
+): Promise<HfChatTypes.Response> {
+  // TODO validate the model is supported
+  const url = options.apiUrl || HF_MODEL_API_URL + request.model;
+
+  const response = await POST(url, {
+    headers: headers(options.accessToken),
+    body: JSON.stringify({ ...request, stream: false }),
+    fetch: options.fetch,
+  });
+
+  return response.json();
+}
+
+export class HfGeneration {
+  static run = run;
+}

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -52,6 +52,7 @@ export namespace HfChatTypes {
   export type GeneratedText = {
     generated_text: string;
   };
+
   // https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
   export type Response = GeneratedText | GeneratedText[];
 

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -6,7 +6,7 @@ import { POST } from '@axflow/models/utils';
 
 // https://huggingface.co/docs/api-inference/quicktour#running-inference-with-api-requests
 const HF_MODEL_API_URL = 'https://api-inference.huggingface.co/models/';
-const SUPPORTED_MODELS = ['gpt2'];
+// const SUPPORTED_MODELS = ['gpt2'];
 
 function headers(accessToken?: string) {
   const headers: Record<string, string> = {
@@ -23,12 +23,13 @@ export namespace HfChatTypes {
   // https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
   export type Request = {
     model: string;
+    stream?: boolean;
     inputs: string;
-    parameters: {
+    parameters?: {
       top_k?: number;
       top_p?: number;
       // Float range from 0.00 to 100.00. Default is 1.0
-      temperature: number;
+      temperature?: number;
       repetition_penalty?: number;
       max_new_tokens?: number;
       // In seconds
@@ -37,7 +38,7 @@ export namespace HfChatTypes {
       num_return_sequences?: number;
       do_sample?: boolean;
     };
-    options: {
+    options?: {
       use_cache?: boolean;
       wait_for_model?: boolean;
     };
@@ -65,13 +66,21 @@ async function run(
 
   const response = await POST(url, {
     headers: headers(options.accessToken),
-    body: JSON.stringify({ ...request, stream: false }),
+    body: JSON.stringify({ ...request }),
     fetch: options.fetch,
   });
 
   return response.json();
 }
 
+// async function stream(
+//   request: HfChatTypes.Request,
+//   options: HfChatTypes.RequestOptions
+// ): Promise<ReadableStream<HfChatTypes.Response>> {
+//   return Promise.resolve();
+// }
+
 export class HfGeneration {
   static run = run;
+  // static stream = stream;
 }

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -1,4 +1,5 @@
-import { POST } from '@axflow/models/utils';
+import { POST } from '@axflow/models/shared';
+import { inspect } from 'util';
 
 // With Hugging Face, we need to first choose a "task" and then pick a compatible model.
 // The tasks we are using (for llama2 for instance): 'text-generation'
@@ -10,7 +11,8 @@ const HF_MODEL_API_URL = 'https://api-inference.huggingface.co/models/';
 
 function headers(accessToken?: string) {
   const headers: Record<string, string> = {
-    accept: 'application/json',
+    // accept: 'application/json',
+    // accept: 'text/event-stream',
     'content-type': 'application/json',
   };
   if (typeof accessToken === 'string') {
@@ -64,11 +66,14 @@ async function run(
   // TODO validate the model is supported
   const url = options.apiUrl || HF_MODEL_API_URL + request.model;
 
+  const headers_ = headers(options.accessToken);
+  console.log(headers_);
   const response = await POST(url, {
-    headers: headers(options.accessToken),
-    body: JSON.stringify({ ...request }),
+    headers: headers_,
+    body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
   });
+  console.log(inspect(response));
 
   return response.json();
 }

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -26,7 +26,6 @@ export namespace HfChatTypes {
     parameters?: {
       top_k?: number;
       top_p?: number;
-      // Float range from 0.00 to 100.00. Default is 1.0
       temperature?: number;
       repetition_penalty?: number;
       max_new_tokens?: number;

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -7,9 +7,10 @@ import { HttpError, POST } from '@axflow/models/shared';
 const HUGGING_FACE_MODEL_API_URL = 'https://api-inference.huggingface.co/models/';
 const HUGGING_FACE_STOP_TOKEN = '</s>';
 
-function headers(accessToken?: string) {
+function headers(accessToken?: string, customHeaders?: Record<string, string>) {
   const headers: Record<string, string> = {
     accept: 'application/json',
+    ...customHeaders,
     'content-type': 'application/json',
   };
   if (typeof accessToken === 'string') {
@@ -45,6 +46,7 @@ export namespace HuggingFaceTextGenerationTypes {
     accessToken?: string;
     apiUrl?: string;
     fetch?: typeof fetch;
+    headers?: Record<string, string>;
   };
 
   export type GeneratedText = {
@@ -83,6 +85,7 @@ export namespace HuggingFaceTextGenerationTypes {
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns The response body from HF. See their documentation linked above for details
  */
 async function run(
@@ -91,7 +94,7 @@ async function run(
 ): Promise<HuggingFaceTextGenerationTypes.Response> {
   const url = options.apiUrl || HUGGING_FACE_MODEL_API_URL + request.model;
 
-  const headers_ = headers(options.accessToken);
+  const headers_ = headers(options.accessToken, options.headers);
   const body = JSON.stringify({ ...request, stream: false });
   const response = await POST(url, {
     headers: headers_,
@@ -112,6 +115,7 @@ async function run(
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -120,7 +124,7 @@ async function streamBytes(
 ): Promise<ReadableStream<Uint8Array>> {
   const url = options.apiUrl || HUGGING_FACE_MODEL_API_URL + request.model;
 
-  const headers_ = headers(options.accessToken);
+  const headers_ = headers(options.accessToken, options.headers);
   const body = JSON.stringify({ ...request, stream: true });
   try {
     const response = await POST(url, {
@@ -180,6 +184,7 @@ function chunkToToken(chunk: HuggingFaceTextGenerationTypes.Chunk) {
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API
  *
  *   Example chunk:
@@ -208,6 +213,7 @@ async function stream(
  * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -72,6 +72,18 @@ export namespace HuggingFaceTextGenerationTypes {
   };
 }
 
+/**
+ * Run a textGeneration task against the HF inference API
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns The response body from HF. See their documentation linked above for details
+ */
 async function run(
   request: HuggingFaceTextGenerationTypes.Request,
   options: HuggingFaceTextGenerationTypes.RequestOptions,
@@ -89,6 +101,18 @@ async function run(
   return response.json();
 }
 
+/**
+ * Stream a textGeneration task against the HF inference API. The resulting stream is the raw unmodified bytes from the API
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of bytes directly from the API.
+ */
 async function streamBytes(
   request: HuggingFaceTextGenerationTypes.Request,
   options: HuggingFaceTextGenerationTypes.RequestOptions,
@@ -141,6 +165,25 @@ function chunkToToken(chunk: HuggingFaceTextGenerationTypes.Chunk) {
   return chunk.token.text;
 }
 
+/**
+ * Stream a textGeneration task against the HF inference API. The resulting stream is the parsed stream data as JavaScript objects.
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of objects representing each chunk from the API
+ *
+ *   Example chunk:
+ *     {
+ *       token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
+ *       generated_text: null,
+ *       details: null
+ *     }
+ */
 async function stream(
   request: HuggingFaceTextGenerationTypes.Request,
   options: HuggingFaceTextGenerationTypes.RequestOptions,
@@ -149,6 +192,18 @@ async function stream(
   return byteStream.pipeThrough(new HuggingFaceDecoderStream(noop));
 }
 
+/**
+ * Run a streaming completion against the HF inference API. The resulting stream emits only the string tokens.
+ *
+ * @see https://huggingface.co/docs/api-inference/detailed_parameters#text-generation-task
+ *
+ * @param request The request body sent to HF. See their documentation linked above for details
+ * @param options
+ * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
+ * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
+ * @returns A stream of tokens from the API.
+ */
 async function streamTokens(
   request: HuggingFaceTextGenerationTypes.Request,
   options: HuggingFaceTextGenerationTypes.RequestOptions,
@@ -157,6 +212,9 @@ async function streamTokens(
   return byteStream.pipeThrough(new HuggingFaceDecoderStream(chunkToToken));
 }
 
+/**
+ * An object that encapsulates methods for calling the HF inference API
+ */
 export class HuggingFaceGeneration {
   static run = run;
   static streamBytes = streamBytes;

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -40,7 +40,11 @@ describe('huggingface textGeneration task', () => {
             temperature: 0.1,
           },
         },
-        { accessToken: 'hf_not-real', fetch: fetchSpy as any },
+        {
+          accessToken: 'hf_not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
       );
       expect(response).toEqual([
         {
@@ -58,6 +62,7 @@ describe('huggingface textGeneration task', () => {
         headers: {
           accept: 'application/json',
           authorization: 'Bearer hf_not-real',
+          'x-my-custom-header': 'custom-value',
           'content-type': 'application/json',
         },
       });
@@ -148,7 +153,12 @@ describe('huggingface textGeneration task', () => {
           max_new_tokens: 250,
         },
       },
-      { accessToken: 'hf_123', fetch: fetchSpy as any, apiUrl: 'https://custom.api.endpoint' },
+      {
+        accessToken: 'hf_123',
+        fetch: fetchSpy as any,
+        apiUrl: 'https://custom.api.endpoint',
+        headers: { 'x-my-custom-header': 'custom-value' },
+      },
     );
 
     let totalResp = '';
@@ -166,6 +176,7 @@ describe('huggingface textGeneration task', () => {
       headers: {
         accept: 'application/json',
         authorization: 'Bearer hf_123',
+        'x-my-custom-header': 'custom-value',
         'content-type': 'application/json',
       },
     });

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -87,7 +87,6 @@ describe('huggingface textGeneration task', () => {
             temperature: 0.1,
           },
         },
-        // TODO mock out the calls later. This is an "integration test" for now
         { accessToken: 'hf_123', fetch: fetchSpy as any },
       );
 

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -5,15 +5,15 @@ describe('run', () => {
     try {
       const response = await HfGeneration.run(
         {
-          model: 'gpt2',
+          model: 'google/flan-t5-xxl',
           stream: true,
-          inputs: 'The answer to the universe is',
+          inputs: 'Whats the best way to make a chicken pesto dish?',
           parameters: {
             temperature: 0,
           },
         },
         // TODO mock out the calls later. This is an "integration test" for now
-        { accessToken: process.env.HF_TOKEN! },
+        { accessToken: process.env.HF_TOKEN! }
       );
 
       console.log('response from HF:\n', response);

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -1,0 +1,24 @@
+import { HfGeneration } from '../../src/huggingface/text-generation';
+
+describe('run', () => {
+  it('executes a generation', async () => {
+    try {
+      const response = await HfGeneration.run(
+        {
+          model: 'gpt2',
+          stream: true,
+          inputs: 'The answer to the universe is',
+          parameters: {
+            temperature: 0,
+          },
+        },
+        // TODO mock out the calls later. This is an "integration test" for now
+        { accessToken: process.env.HF_TOKEN! },
+      );
+
+      console.log('response from HF:\n', response);
+    } catch (e) {
+      console.log('error', e);
+    }
+  });
+});

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -14,7 +14,6 @@ describe('huggingface textGeneration task', () => {
       { encoding: 'utf-8' },
     );
     streamingGenerationResponseWithEndToken = await fs.readFile(
-      // Path.join(__dirname, 'streaming-text-generation-response.txt'),
       Path.join(__dirname, 'terminated-streaming-generation-response.txt'),
       { encoding: 'utf-8' },
     );
@@ -197,7 +196,7 @@ describe('huggingface textGeneration task', () => {
   });
 
   describe('streamTokens', () => {
-    it('executes a stream() properly)', async () => {
+    it('executes a streamTokens() properly)', async () => {
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingGenerationResponse),
       });

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -1,24 +1,87 @@
 import { HfGeneration } from '../../src/huggingface/text-generation';
+import { inspect } from 'util';
+import { isHttpError } from '../../src/shared/http';
+import { StreamToIterable } from '../../src/shared';
 
-describe('run', () => {
-  it('executes a generation', async () => {
+describe('huggingface', () => {
+  it('executes a run() properly)', async () => {
     try {
       const response = await HfGeneration.run(
         {
-          model: 'google/flan-t5-xxl',
-          stream: true,
+          model: 'gpt2',
           inputs: 'Whats the best way to make a chicken pesto dish?',
           parameters: {
-            temperature: 0,
+            temperature: 0.1,
           },
         },
         // TODO mock out the calls later. This is an "integration test" for now
-        { accessToken: process.env.HF_TOKEN! }
+        { accessToken: process.env.HF_TOKEN! },
       );
+      console.log(response);
+      expect(response).toBeDefined();
+    } catch (e: unknown) {
+      if (isHttpError(e)) {
+        console.log(' We have an httperror:\n', inspect(e));
+      } else {
+        console.log('Error:\n', e);
+      }
+    }
+  });
+  // This might be normal, but the chunks are all uint8 arrays
+  it('executes a streamBytes() properly)', async () => {
+    try {
+      const response = await HfGeneration.streamBytes(
+        {
+          model: 'google/flan-t5-xxl',
+          inputs: 'Whats the best way to make a chicken pesto dish?',
+          parameters: {
+            temperature: 0.1,
+          },
+        },
+        // TODO mock out the calls later. This is an "integration test" for now
+        { accessToken: process.env.HF_TOKEN! },
+      );
+      let totalResp = '';
+      for await (const chunk of StreamToIterable(response)) {
+        var enc = new TextDecoder('utf-8');
 
-      console.log('response from HF:\n', response);
-    } catch (e) {
-      console.log('error', e);
+        console.log(enc.decode(chunk));
+        totalResp += enc.decode(chunk);
+      }
+
+      console.log(totalResp);
+      expect(response).toBeDefined();
+    } catch (e: unknown) {
+      if (isHttpError(e)) {
+        console.log(' We have an httperror:\n', inspect(e));
+      } else {
+        console.log('Error:\n', e);
+      }
+    }
+  });
+
+  it('executes a stream() properly)', async () => {
+    try {
+      const response = await HfGeneration.stream(
+        {
+          model: 'google/flan-t5-xxl',
+          inputs: 'Whats the best way to make a chicken pesto dish?',
+          parameters: {
+            temperature: 0.1,
+          },
+        },
+        // TODO mock out the calls later. This is an "integration test" for now
+        { accessToken: process.env.HF_TOKEN! },
+      );
+      for await (const chunk of StreamToIterable(response)) {
+        console.log(chunk);
+      }
+    } catch (e: unknown) {
+      if (isHttpError(e)) {
+        console.log(' We have an httperror:\n', inspect(e));
+      } else {
+        console.log('Error:\n', e);
+      }
     }
   });
 });

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -84,4 +84,29 @@ describe('huggingface', () => {
       }
     }
   });
+
+  it('executes a streamTokens() properly)', async () => {
+    try {
+      const response = await HfGeneration.streamTokens(
+        {
+          model: 'google/flan-t5-xxl',
+          inputs: 'Whats the best way to make a chicken pesto dish?',
+          parameters: {
+            temperature: 0.1,
+          },
+        },
+        // TODO mock out the calls later. This is an "integration test" for now
+        { accessToken: process.env.HF_TOKEN! },
+      );
+      for await (const chunk of StreamToIterable(response)) {
+        console.log(chunk);
+      }
+    } catch (e: unknown) {
+      if (isHttpError(e)) {
+        console.log(' We have an httperror:\n', inspect(e));
+      } else {
+        console.log('Error:\n', e);
+      }
+    }
+  });
 });

--- a/packages/models/test/huggingface/generation.test.ts
+++ b/packages/models/test/huggingface/generation.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import Path from 'node:path';
-import { HfGeneration } from '../../src/huggingface/text-generation';
+import { HuggingFaceGeneration } from '../../src/huggingface/text-generation';
 import { StreamToIterable } from '../../src/shared';
 import { createFakeFetch, createUnpredictableByteStream } from '../utils';
 
@@ -26,7 +26,7 @@ describe('huggingface textGeneration task', () => {
           },
         ],
       });
-      const response = await HfGeneration.run(
+      const response = await HuggingFaceGeneration.run(
         {
           model: 'gpt2',
           inputs: 'Whats the best way to make a chicken pesto dish?',
@@ -76,7 +76,7 @@ describe('huggingface textGeneration task', () => {
         body: createUnpredictableByteStream(streamingGenerationResponse),
       });
 
-      const response = await HfGeneration.stream(
+      const response = await HuggingFaceGeneration.stream(
         {
           model: 'google/flan-t5-xxl',
           inputs: 'Whats the best way to make a chicken pesto dish?',
@@ -132,7 +132,7 @@ describe('huggingface textGeneration task', () => {
         body: createUnpredictableByteStream(streamingGenerationResponse),
       });
 
-      const response = await HfGeneration.streamTokens(
+      const response = await HuggingFaceGeneration.streamTokens(
         {
           model: 'google/flan-t5-xxl',
           inputs: 'Whats the best way to make a chicken pesto dish?',

--- a/packages/models/test/huggingface/streaming-text-generation-response.txt
+++ b/packages/models/test/huggingface/streaming-text-generation-response.txt
@@ -1,0 +1,40 @@
+data:{"token":{"id":304,"text":" To","logprob":-0.012886047,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":7,"text":"s","logprob":-0.37695312,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":7,"text":"s","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":3,"text":" ","logprob":-0.27612305,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":9,"text":"a","logprob":-0.0035820007,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":3,"text":" ","logprob":-0.21728516,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":8861,"text":"pound","logprob":-0.00007033348,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":13,"text":" of","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":3832,"text":" chicken","logprob":-0.1274414,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":6748,"text":" breast","logprob":-9.536743e-7,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":7,"text":"s","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":28,"text":" with","logprob":-0.0000021457672,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":3,"text":" ","logprob":-0.022994995,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":9,"text":"a","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":4119,"text":" cup","logprob":-0.03366089,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":13,"text":" of","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":6256,"text":" pest","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":32,"text":"o","logprob":0.0,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":6,"text":",","logprob":-0.16491699,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":3,"text":" ","logprob":-0.09289551,"special":false},"generated_text":"Toss a pound of chicken breasts with a cup of pesto, ","details":null}
+

--- a/packages/models/test/huggingface/terminated-streaming-generation-response.txt
+++ b/packages/models/test/huggingface/terminated-streaming-generation-response.txt
@@ -1,0 +1,42 @@
+data:{"token":{"id":13,"text":"\n","logprob":-0.7504883,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":1576,"text":"The","logprob":-1.8740234,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":6575,"text":" sun","logprob":-1.265625,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":6166,"text":" sets","logprob":-0.075683594,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":14205,"text":" slowly","logprob":-0.70703125,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":13,"text":"\n","logprob":-0.37646484,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":29954,"text":"G","logprob":-0.086242676,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":1025,"text":"old","logprob":-0.00007736683,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":264,"text":"en","logprob":-0.00004851818,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":298,"text":" h","logprob":-0.07861328,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":1041,"text":"ues","logprob":-0.00085544586,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":2501,"text":" upon","logprob":-0.003145218,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":278,"text":" the","logprob":-0.00012803078,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":7205,"text":" sea","logprob":-0.0038108826,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":13,"text":"\n","logprob":-0.0006041527,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":15666,"text":"Pe","logprob":-0.01184082,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":815,"text":"ace","logprob":-0.000009775162,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":1319,"text":"ful","logprob":-0.004852295,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":11005,"text":" evening","logprob":-0.0129852295,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":14744,"text":" sky","logprob":-0.0037250519,"special":false},"generated_text":null,"details":null}
+
+data:{"token":{"id":2,"text":"y</s>","logprob":-0.35229492,"special":true},"generated_text":"\nThe sun sets slowly\nGolden hues upon the sea\nPeaceful evening sky","details":null}
+

--- a/packages/models/tsup.config.ts
+++ b/packages/models/tsup.config.ts
@@ -44,6 +44,13 @@ export default defineConfig([
     dts: true,
   },
   {
+    entry: ['src/huggingface/text-generation.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist/huggingface',
+    external: [/^@axflow\/models\//],
+    dts: true,
+  },
+  {
     entry: ['src/react/index.ts'],
     format: ['cjs', 'esm'],
     outDir: 'dist/react',


### PR DESCRIPTION
This change introduces support for text-generation tasks through Hugging Face. Hugging Face has many different "tasks" (see screenshot below). This PR introduces support for  `text-generation` (the most popular) and conversational. These map somewhat to completion & chat respectively, for openAI.

We introduce `run()`, `stream()`, `streamBytes()` and `streamTokens()` for text-generation tasks. When the model doesn't support streaming, we bubble that error up to the user.

HF supports multiple ways to do inference:

* public inference endpoint, using their public API base (the default)
* through their ["inference endpoints"](https://huggingface.co/docs/inference-endpoints/index) product

These have both been tested and work with the changes.

Note: we handle stop tokens here by stripping them from the `streamTokens()` response. Importantly, they are still sent to down during the `stream()` call, but can be identified in the `Chunk` type by having the property: `special: true`.
## Testing

This was tested with different models, notably `gpt2` for `run()` and `google/flan-t5-xxl` for streaming. 
It was also tested using a live inference endpoint for llama-2-7-B.
The responses from those tests were then hardcoded into text files and mocked into unit tests.

## TODO
These do not necessarily block the PR, but need to be done:
 - [x] test against the inference endpoint. This likely means deploying a model on HF
 - [x] docs


## Appendix

HF tasks

![CleanShot 2023-09-12 at 19 40 42](https://github.com/axflow/axflow/assets/1666947/2be9dcac-2d5b-4644-b073-0167d35b1f85)
