### PR TITLE
Add streamJsonResponse for Node ServerResponse objects

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
                   { text: 'CohereGeneration', link: '/documentation/models/cohere-generation' },
                   { text: 'CohereEmbedding', link: '/documentation/models/cohere-embedding' },
                   { text: 'React', link: '/documentation/models/react' },
+                  { text: 'Node', link: '/documentation/models/node' },
                   { text: 'Shared', link: '/documentation/models/shared' },
                 ],
               },

--- a/docs/documentation/models/node.md
+++ b/docs/documentation/models/node.md
@@ -8,7 +8,7 @@ import {streamJsonResponse} from '@axflow/models/node';
 
 ## `streamJsonResponse`
 
-This function enables pipeing chunks from a `ReadableStream` to a Node.js `ServerResponse` object. This is the Node.js equivalent of the [`StreamingJsonResponse`](/documentation/models/shared.md#streamingjsonresponse).
+This function enables pipeing chunks from a `ReadableStream` to a Node.js `ServerResponse` object. This is the Node.js standard library equivalent of [`StreamingJsonResponse`](/documentation/models/shared.md#streamingjsonresponse).
 
 ```ts
 /**

--- a/docs/documentation/models/node.md
+++ b/docs/documentation/models/node.md
@@ -1,0 +1,43 @@
+# @axflow/models/node
+
+Functions for working with objects from the Node standard library.
+
+```ts
+import {streamJsonResponse} from '@axflow/models/node';
+```
+
+## `streamJsonResponse`
+
+This function enables pipeing chunks from a `ReadableStream` to a Node.js `ServerResponse` object. This is the Node.js equivalent of the [`StreamingJsonResponse`](/documentation/models/shared.md#streamingjsonresponse).
+
+```ts
+/**
+ * Pipe a `ReadableStream` through a Node `ServerResponse` object. This is
+ * useful in environments using the Node.js standard library, like express.
+ *
+ * Example:
+ *
+ *     // Express JS route
+ *     app.post("/api/chat", async (req, res) => {
+ *       const chatRequest = req.body;
+ *
+ *       const stream = await OpenAIChat.streamTokens(chatRequest, {
+ *         apiKey: process.env.OPENAI_API_KEY,
+ *       });
+ *
+ *       return streamJsonResponse(stream, res);
+ *     });
+ *
+ * @param stream A readable stream of chunks to encode as newline-delimited JSON.
+ * @param response A Node.js `ServerResponse` object to pipe `stream` to.
+ * @param options
+ * @param options.status HTTP response status.
+ * @param options.headers HTTP response headers.
+ * @param options.data Additional data to enqueue to the output stream. If data is a `Promise`, the stream will wait for it to resolve and enqueue its resolved values before closing.
+ */
+declare function streamJsonResponse(stream: ReadableStream, response: ServerResponse, options?: {
+  headers?: Record<string, string>;
+  status?: number;
+  data?: JSONValueType[] | Promise<JSONValueType[]>;
+}): Promise<void>;
+```

--- a/docs/guides/models/streaming.md
+++ b/docs/guides/models/streaming.md
@@ -50,6 +50,10 @@ export async function POST(request: Request) {
 
 A `StreamingJsonResponse` object is returned from the handler function which will stream each token from the LLM back to the client.
 
+::: tip
+For environments that use Node.js `ServerResponse` objects, like express.js, use the [`streamJsonResponse`](/documentation/models/node.md#streamjsonresponse) function from the `@axflow/models/node` subpath export.
+:::
+
 ### Deconstructing the response
 
 `StreamingJsonResponse` converts each chunk of the stream into [newline-delimited JSON](http://ndjson.org). Newline-delimited JSON is easy to extend, parse, and reason about.

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -91,6 +91,9 @@
       "react": [
         "./dist/react/index.d.ts"
       ],
+      "node": [
+        "./dist/node/index.d.ts"
+      ],
       "shared": [
         "./dist/shared/index.d.ts"
       ]
@@ -139,6 +142,12 @@
       "import": "./dist/react/index.mjs",
       "module": "./dist/react/index.mjs",
       "require": "./dist/react/index.js"
+    },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node/index.mjs",
+      "module": "./dist/node/index.mjs",
+      "require": "./dist/node/index.js"
     },
     "./shared": {
       "types": "./dist/shared/index.d.ts",

--- a/packages/models/src/node/index.ts
+++ b/packages/models/src/node/index.ts
@@ -1,0 +1,53 @@
+import { ServerResponse } from 'node:http';
+import { NdJsonStream, StreamToIterable, type JSONValueType } from '@axflow/models/shared';
+
+/**
+ * Pipe a `ReadableStream` through a Node `ServerResponse` object. This is
+ * useful in environments using the Node.js standard library, like express.
+ *
+ * Example:
+ *
+ *     // Express JS route
+ *     app.post("/api/chat", async (req, res) => {
+ *       const chatRequest = req.body;
+ *
+ *       const stream = await OpenAIChat.streamTokens(chatRequest, {
+ *         apiKey: process.env.OPENAI_API_KEY,
+ *       });
+ *
+ *       return streamJsonResponse(stream, res);
+ *     });
+ *
+ * @param stream A readable stream of chunks to encode as newline-delimited JSON.
+ * @param response A Node.js `ServerResponse` object to pipe `stream` to.
+ * @param options
+ * @param options.status HTTP response status.
+ * @param options.headers HTTP response headers.
+ * @param options.data Additional data to enqueue to the output stream. If data is a `Promise`, the stream will wait for it to resolve and enqueue its resolved values before closing.
+ */
+export async function streamJsonResponse(
+  stream: ReadableStream,
+  response: ServerResponse,
+  options?: {
+    headers?: Record<string, string>;
+    status?: number;
+    data?: JSONValueType[] | Promise<JSONValueType[]>;
+  },
+) {
+  options ??= {};
+
+  response.writeHead(options.status || 200, {
+    ...options.headers,
+    ...NdJsonStream.headers,
+  });
+
+  const ndJsonStream = NdJsonStream.encode(stream, {
+    data: options.data,
+  });
+
+  for await (const chunk of StreamToIterable(ndJsonStream)) {
+    response.write(chunk);
+  }
+
+  response.end();
+}

--- a/packages/models/test/node/index.test.ts
+++ b/packages/models/test/node/index.test.ts
@@ -1,0 +1,158 @@
+import { streamJsonResponse } from '../../src/node';
+import { ServerResponse } from 'node:http';
+
+function delay<T>(ms: number, value: T): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
+}
+
+function createMockResponse() {
+  return {
+    writeHead: jest.fn(),
+    write: jest.fn(),
+    end: jest.fn(),
+  } as any as ServerResponse;
+}
+
+describe('streamJsonResponse', () => {
+  const chunks = [
+    { content: 'A' },
+    { content: ' Nd' },
+    { content: 'Json' },
+    { content: ' stream' },
+  ];
+
+  const decoder = new TextDecoder();
+
+  let source: ReadableStream<{ content: string }>;
+
+  beforeEach(() => {
+    source = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+  });
+
+  it('can stream an ndjson response through a Node ServerResponse', async () => {
+    const response = createMockResponse();
+
+    await streamJsonResponse(source, response);
+
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(200, {
+      'content-type': 'application/x-ndjson; charset=utf-8',
+    });
+
+    const writeMock = response.write as jest.Mock;
+
+    expect(writeMock).toHaveBeenCalledTimes(4);
+    const ndjson = writeMock.mock.calls.map((args) => decoder.decode(args[0]));
+    expect(ndjson).toEqual([
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+    ]);
+
+    expect(response.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('can stream an ndjson response through a Node ServerResponse with options', async () => {
+    const response = createMockResponse();
+
+    await streamJsonResponse(source, response, {
+      status: 201,
+      headers: { 'x-my-custom-header': 'application/custom-header' },
+    });
+
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(201, {
+      'content-type': 'application/x-ndjson; charset=utf-8',
+      'x-my-custom-header': 'application/custom-header',
+    });
+
+    const writeMock = response.write as jest.Mock;
+
+    expect(writeMock).toHaveBeenCalledTimes(4);
+    const ndjson = writeMock.mock.calls.map((args) => decoder.decode(args[0]));
+    expect(ndjson).toEqual([
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+    ]);
+
+    expect(response.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('can stream an ndjson response through a Node ServerResponse with additional data', async () => {
+    const response = createMockResponse();
+
+    const additionalData = [
+      { some: 'extra', data: 'here' },
+      { some: 'more', data: 'here' },
+    ];
+
+    await streamJsonResponse(source, response, {
+      data: additionalData,
+    });
+
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(200, {
+      'content-type': 'application/x-ndjson; charset=utf-8',
+    });
+
+    const writeMock = response.write as jest.Mock;
+
+    expect(writeMock).toHaveBeenCalledTimes(6);
+    const ndjson = writeMock.mock.calls.map((args) => decoder.decode(args[0]));
+    expect(ndjson).toEqual([
+      '{"type":"data","value":{"some":"extra","data":"here"}}\n',
+      '{"type":"data","value":{"some":"more","data":"here"}}\n',
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+    ]);
+
+    expect(response.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('can stream an ndjson response through a Node ServerResponse with async additional data', async () => {
+    const response = createMockResponse();
+
+    const additionalData = delay(2, [
+      { some: 'extra', data: 'here' },
+      { some: 'more', data: 'here' },
+    ]);
+
+    await streamJsonResponse(source, response, {
+      data: additionalData,
+    });
+
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(200, {
+      'content-type': 'application/x-ndjson; charset=utf-8',
+    });
+
+    const writeMock = response.write as jest.Mock;
+
+    expect(writeMock).toHaveBeenCalledTimes(6);
+    const ndjson = writeMock.mock.calls.map((args) => decoder.decode(args[0]));
+    expect(ndjson).toEqual([
+      '{"type":"chunk","value":{"content":"A"}}\n',
+      '{"type":"chunk","value":{"content":" Nd"}}\n',
+      '{"type":"chunk","value":{"content":"Json"}}\n',
+      '{"type":"chunk","value":{"content":" stream"}}\n',
+      '{"type":"data","value":{"some":"extra","data":"here"}}\n',
+      '{"type":"data","value":{"some":"more","data":"here"}}\n',
+    ]);
+
+    expect(response.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/models/tsup.config.ts
+++ b/packages/models/tsup.config.ts
@@ -51,6 +51,13 @@ export default defineConfig([
     dts: true,
   },
   {
+    entry: ['src/node/index.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist/node',
+    external: [/^@axflow\/models\//],
+    dts: true,
+  },
+  {
     entry: ['src/shared/index.ts'],
     format: ['cjs', 'esm'],
     outDir: 'dist/shared',


### PR DESCRIPTION
This introduces support for environments that use the Node [ServerResponse](https://nodejs.org/api/http.html#class-httpserverresponse) objects (e.g., express.js) instead of the newer JavaScript [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects (e.g., Next.js).

This unblocks a couple of users using express.js