### PR TITLE
Support custom headers for model invocations

### DIFF
--- a/docs/documentation/models/anthropic-completion.md
+++ b/docs/documentation/models/anthropic-completion.md
@@ -30,6 +30,7 @@ declare class AnthropicCompletion {
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns Anthropic completion. See Anthropic's documentation for /v1/complete.
  */
 declare function run(
@@ -53,6 +54,7 @@ declare function run(
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -76,6 +78,7 @@ declare function streamBytes(
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -99,6 +102,7 @@ declare function stream(
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/cohere-embedding.md
+++ b/docs/documentation/models/cohere-embedding.md
@@ -26,6 +26,7 @@ declare class CohereEmbedding {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/embed.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns An object consisting of the text embeddings and other metadata. See Cohere's documentation for /v1/embed.
  */
 declare function run(

--- a/docs/documentation/models/cohere-generation.md
+++ b/docs/documentation/models/cohere-generation.md
@@ -29,6 +29,7 @@ declare class CohereGeneration {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns Cohere completion. See Cohere's documentation for /v1/generate.
  */
 declare function run(
@@ -50,6 +51,7 @@ declare function run(
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -71,6 +73,7 @@ declare function streamBytes(
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -92,6 +95,7 @@ declare function stream(
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/openai-chat.md
+++ b/docs/documentation/models/openai-chat.md
@@ -29,6 +29,7 @@ declare class OpenAIChat {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns OpenAI chat completion. See OpenAI's documentation for /v1/chat/completions.
  */
 declare function run(
@@ -50,6 +51,7 @@ declare function run(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -71,6 +73,7 @@ declare function streamBytes(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -92,6 +95,7 @@ declare function stream(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/openai-completion.md
+++ b/docs/documentation/models/openai-completion.md
@@ -29,6 +29,7 @@ declare class OpenAICompletion {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns OpenAI completion. See OpenAI's documentation for /v1/completions.
  */
 declare function run(
@@ -50,6 +51,7 @@ declare function run(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -71,6 +73,7 @@ declare function streamBytes(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -92,6 +95,7 @@ declare function stream(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/openai-embedding.md
+++ b/docs/documentation/models/openai-embedding.md
@@ -26,6 +26,7 @@ declare class OpenAIEmbedding {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns An object consisting of the text embeddings and other metadata. See OpenAI's documentation for /v1/embeddings.
  */
 declare function run(

--- a/docs/guides/models/getting-started.md
+++ b/docs/guides/models/getting-started.md
@@ -206,3 +206,26 @@ for await (const chunk of StreamToIterable(stream)) {
   // Do something with chunk
 }
 ```
+
+### Overriding behavior
+
+The run and stream functions support overriding or customizing some behavior. For example, we support:
+
+1. Supplying a custom `apiUrl` to point to a different API implementation, e.g., proxy or otherwise compatible API.
+2. Supplying custom request headers.
+3. Supplying a custom `fetch` implementation, which could act as a client-side proxy, add logging, or otherwise customize request behavior.
+
+For example:
+
+```ts
+import { CohereGeneration } from '@axflow/models/cohere/generation';
+
+const response = await CohereGeneration.stream({ /* ... */ }, {
+  apiUrl: 'https://api.example.com/v1/generate',
+  headers: {
+    'x-my-custom-header': 'custom-value',
+  }
+});
+```
+
+Additionally, this enables easy client-side usage (e.g., in browsers) because you could have an API proxy that simply adds the api key and forwards the request to the underlying provider.

--- a/packages/models/src/anthropic/completion.ts
+++ b/packages/models/src/anthropic/completion.ts
@@ -19,6 +19,7 @@ export namespace AnthropicCompletionTypes {
     apiUrl?: string;
     version?: string;
     fetch?: typeof fetch;
+    headers?: Record<string, string>;
   };
 
   type Completion = {
@@ -52,10 +53,11 @@ export namespace AnthropicCompletionTypes {
   export type Events = 'completion' | 'ping' | 'error';
 }
 
-function headers(apiKey?: string, version?: string) {
+function headers(apiKey?: string, version?: string, customHeaders?: Record<string, string>) {
   const headers: Record<string, string> = {
     accept: 'application/json',
     'content-type': 'application/json',
+    ...customHeaders,
     'anthropic-version': version || '2023-06-01',
   };
 
@@ -77,6 +79,7 @@ function headers(apiKey?: string, version?: string) {
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns Anthropic completion. See Anthropic's documentation for /v1/complete.
  */
 async function run(
@@ -86,7 +89,7 @@ async function run(
   const url = options.apiUrl || ANTHROPIC_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey, options.version),
+    headers: headers(options.apiKey, options.version, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
   });
@@ -106,6 +109,7 @@ async function run(
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -115,7 +119,7 @@ async function streamBytes(
   const url = options.apiUrl || ANTHROPIC_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey, options.version),
+    headers: headers(options.apiKey, options.version, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
   });
@@ -143,6 +147,7 @@ function noop(chunk: AnthropicCompletionTypes.Chunk) {
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -169,6 +174,7 @@ function chunkToToken(chunk: AnthropicCompletionTypes.Chunk): string {
  * @param options.apiUrl The url of the Anthropic (or compatible) API. Defaults to https://api.anthropic.com/v1/complete.
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/cohere/embedding.ts
+++ b/packages/models/src/cohere/embedding.ts
@@ -38,6 +38,7 @@ export namespace CohereEmbeddingTypes {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/embed.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns An object consisting of the text embeddings and other metadata. See Cohere's documentation for /v1/embed.
  */
 async function run(
@@ -47,7 +48,7 @@ async function run(
   const url = options.apiUrl || COHERE_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify(request),
     fetch: options.fetch,
   });

--- a/packages/models/src/cohere/generation.ts
+++ b/packages/models/src/cohere/generation.ts
@@ -72,6 +72,7 @@ export namespace CohereGenerationTypes {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns Cohere completion. See Cohere's documentation for /v1/generate.
  */
 async function run(
@@ -81,7 +82,7 @@ async function run(
   const url = options.apiUrl || COHERE_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
   });
@@ -99,6 +100,7 @@ async function run(
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -108,7 +110,7 @@ async function streamBytes(
   const url = options.apiUrl || COHERE_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
   });
@@ -134,6 +136,7 @@ function noop(chunk: CohereGenerationTypes.Chunk) {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -158,6 +161,7 @@ function chunkToToken(chunk: CohereGenerationTypes.Chunk) {
  * @param options.apiKey Cohere API key.
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/cohere/shared.ts
+++ b/packages/models/src/cohere/shared.ts
@@ -2,12 +2,14 @@ export type SharedRequestOptions = {
   apiKey?: string;
   apiUrl?: string;
   fetch?: typeof fetch;
+  headers?: Record<string, string>;
 };
 
-export function headers(apiKey?: string) {
+export function headers(apiKey?: string, customHeaders?: Record<string, string>) {
   const headers: Record<string, string> = {
     accept: 'application/json',
     'content-type': 'application/json',
+    ...customHeaders,
   };
 
   if (typeof apiKey === 'string') {

--- a/packages/models/src/openai/chat.ts
+++ b/packages/models/src/openai/chat.ts
@@ -89,6 +89,7 @@ export namespace OpenAIChatTypes {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns OpenAI chat completion. See OpenAI's documentation for /v1/chat/completions.
  */
 async function run(
@@ -98,7 +99,7 @@ async function run(
   const url = options.apiUrl || OPENAI_CHAT_COMPLETIONS_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
   });
@@ -116,6 +117,7 @@ async function run(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -125,7 +127,7 @@ async function streamBytes(
   const url = options.apiUrl || OPENAI_CHAT_COMPLETIONS_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
   });
@@ -151,6 +153,7 @@ function noop(chunk: OpenAIChatTypes.Chunk) {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -175,6 +178,7 @@ function chunkToToken(chunk: OpenAIChatTypes.Chunk) {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/openai/completion.ts
+++ b/packages/models/src/openai/completion.ts
@@ -71,6 +71,7 @@ export namespace OpenAICompletionTypes {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns OpenAI completion. See OpenAI's documentation for /v1/completions.
  */
 async function run(
@@ -80,7 +81,7 @@ async function run(
   const url = options.apiUrl || OPENAI_COMPLETIONS_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
   });
@@ -98,6 +99,7 @@ async function run(
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -107,7 +109,7 @@ async function streamBytes(
   const url = options.apiUrl || OPENAI_COMPLETIONS_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
   });
@@ -133,6 +135,7 @@ function noop(chunk: OpenAICompletionTypes.Chunk) {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -157,6 +160,7 @@ function chunkToToken(chunk: OpenAICompletionTypes.Chunk) {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/openai/embedding.ts
+++ b/packages/models/src/openai/embedding.ts
@@ -41,6 +41,7 @@ export namespace OpenAIEmbeddingTypes {
  * @param options.apiKey OpenAI API key.
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
  * @returns An object consisting of the text embeddings and other metadata. See OpenAI's documentation for /v1/embeddings.
  */
 async function run(
@@ -50,7 +51,7 @@ async function run(
   const url = options.apiUrl || OPENAI_COMPLETIONS_API_URL;
 
   const response = await POST(url, {
-    headers: headers(options.apiKey),
+    headers: headers(options.apiKey, options.headers),
     body: JSON.stringify(request),
     fetch: options.fetch,
   });

--- a/packages/models/src/openai/shared.ts
+++ b/packages/models/src/openai/shared.ts
@@ -2,12 +2,14 @@ export type SharedRequestOptions = {
   apiKey?: string;
   apiUrl?: string;
   fetch?: typeof fetch;
+  headers?: Record<string, string>;
 };
 
-export function headers(apiKey?: string) {
+export function headers(apiKey?: string, customHeaders?: Record<string, string>) {
   const headers: Record<string, string> = {
     accept: 'application/json',
     'content-type': 'application/json',
+    ...customHeaders,
   };
 
   if (typeof apiKey === 'string') {

--- a/packages/models/test/anthropic/completion.test.ts
+++ b/packages/models/test/anthropic/completion.test.ts
@@ -68,6 +68,44 @@ describe('anthropic completion', () => {
         stream: false,
       });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          completion: ' Hello!',
+          stop_reason: 'stop_sequence',
+          model: 'claude-2.0',
+          stop: '\n\nHuman:',
+          log_id: 'bfd6321f190b5c6f55ca91cf2956f8b956654b7491af118ba18559d7c24a4684',
+        },
+      });
+
+      await AnthropicCompletion.run(
+        {
+          model: 'claude-2',
+          prompt: '\n\nHuman: Hello, world!\n\nAssistant:',
+          max_tokens_to_sample: 256,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.anthropic.com/v1/complete', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'x-api-key': 'sk-not-real',
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -117,6 +155,38 @@ describe('anthropic completion', () => {
         prompt: '\n\nHuman: Hello, world!\n\nAssistant:',
         max_tokens_to_sample: 256,
         stream: true,
+      });
+    });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingCompletionResponse),
+      });
+
+      await AnthropicCompletion.stream(
+        {
+          model: 'claude-2',
+          prompt: '\n\nHuman: Hello, world!\n\nAssistant:',
+          max_tokens_to_sample: 256,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.anthropic.com/v1/complete', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'x-api-key': 'sk-not-real',
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
       });
     });
   });

--- a/packages/models/test/cohere/embedding.test.ts
+++ b/packages/models/test/cohere/embedding.test.ts
@@ -41,5 +41,37 @@ describe('cohere embedding', () => {
 
       expect(bodyArgument).toEqual({ texts: ['How can I deploy to fly.io?'] });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          id: '2dac6b8b-2038-410d-9674-8b5e1b4eef47',
+          texts: ['How can I deploy to fly.io?'],
+          embeddings: [1, 2, 3, 4, 5, 6],
+          meta: { api_version: { version: '1' } },
+        },
+      });
+
+      await CohereEmbedding.run(
+        { texts: ['How can I deploy to fly.io?'] },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.cohere.ai/v1/embed', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 });

--- a/packages/models/test/cohere/generation.test.ts
+++ b/packages/models/test/cohere/generation.test.ts
@@ -73,6 +73,46 @@ describe('cohere generation', () => {
         stream: false,
       });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          id: 'a427751b-776f-49a8-b078-3b36acd206d1',
+          generations: [
+            {
+              id: '9286db4a-c632-4a43-b9c0-c236bb3a82d5',
+              text: ' LLMs, or large language models, are artificial intelligence models that are designed to perform language-based tasks such as generating text, answering questions, and performing language-related analyses. They are trained on massive amounts of text data, which helps them learn to understand and generate language in a way that is similar to how humans do it.',
+            },
+          ],
+          prompt: 'Please explain to me how LLMs work in two sentences or less',
+          meta: { api_version: { version: '1' } },
+        },
+      });
+
+      await CohereGeneration.run(
+        {
+          prompt: 'Please explain to me how LLMs work in two sentences or less',
+          max_tokens: 80,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.cohere.ai/v1/generate', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -119,6 +159,36 @@ describe('cohere generation', () => {
         prompt: 'Please explain to me how LLMs work in two sentences or less',
         max_tokens: 80,
         stream: true,
+      });
+    });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingGenerationResponse),
+      });
+
+      await CohereGeneration.stream(
+        {
+          prompt: 'Please explain to me how LLMs work in two sentences or less',
+          max_tokens: 80,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.cohere.ai/v1/generate', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
       });
     });
   });

--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -75,6 +75,55 @@ describe('openai chat', () => {
         stream: false,
       });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          id: 'chatcmpl-7q9iFa9eplmD2n3hGPwJ6iBLlUQkY',
+          object: 'chat.completion',
+          created: 1692664747,
+          model: 'gpt-4-0613',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content:
+                  'The Eiffel Tower is a wrought-iron lattice tower located in Paris, France and is a globally recognised symbol.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 23, completion_tokens: 24, total_tokens: 47 },
+        },
+      });
+
+      await OpenAIChat.run(
+        {
+          model: 'gpt-4',
+          messages: [
+            { role: 'user', content: 'Using no more than 20 words, what is the Eiffel tower?' },
+          ],
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/chat/completions', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -127,6 +176,38 @@ describe('openai chat', () => {
           { role: 'user', content: 'Using no more than 20 words, what is the Eiffel tower?' },
         ],
         stream: true,
+      });
+    });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingChatResponse),
+      });
+
+      await OpenAIChat.stream(
+        {
+          model: 'gpt-4',
+          messages: [
+            { role: 'user', content: 'Using no more than 20 words, what is the Eiffel tower?' },
+          ],
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/chat/completions', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
       });
     });
   });

--- a/packages/models/test/openai/completion.test.ts
+++ b/packages/models/test/openai/completion.test.ts
@@ -74,6 +74,51 @@ describe('openai chat', () => {
         stream: false,
       });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          id: 'cmpl-7qQ4UuIH02BRy3yAN71b8KeHxN19p',
+          object: 'text_completion',
+          created: 1692727630,
+          model: 'text-davinci-003',
+          choices: [
+            {
+              text: '\n\nTall wrought iron lattice tower in Paris, France, built by Gustave Eiffel in 1889.',
+              index: 0,
+              logprobs: null,
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 15, completion_tokens: 24, total_tokens: 39 },
+        },
+      });
+
+      await OpenAICompletion.run(
+        {
+          model: 'text-davinci-003',
+          prompt: 'Using no more than 20 words, what is the Eiffel tower?',
+          max_tokens: 256,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/completions', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 
   describe('stream', () => {
@@ -124,6 +169,37 @@ describe('openai chat', () => {
         prompt: 'Using no more than 20 words, what is the Eiffel tower?',
         max_tokens: 256,
         stream: true,
+      });
+    });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingChatResponse),
+      });
+
+      await OpenAICompletion.stream(
+        {
+          model: 'text-davinci-003',
+          prompt: 'Using no more than 20 words, what is the Eiffel tower?',
+          max_tokens: 256,
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/completions', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
       });
     });
   });

--- a/packages/models/test/openai/embedding.test.ts
+++ b/packages/models/test/openai/embedding.test.ts
@@ -47,5 +47,40 @@ describe('openai embedding', () => {
         input: 'Using no more than 20 words, what is the Eiffel tower?',
       });
     });
+
+    it('can supply custom headers', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          object: 'list',
+          data: [{ object: 'embedding', index: 0, embedding: [0, 1, 2, 3, 5, 6] }],
+          model: 'text-embedding-ada-002-v2',
+          usage: { prompt_tokens: 8, total_tokens: 8 },
+        },
+      });
+
+      await OpenAIEmbedding.run(
+        {
+          model: 'text-embedding-ada-002',
+          input: 'Using no more than 20 words, what is the Eiffel tower?',
+        },
+        {
+          apiKey: 'sk-not-real',
+          fetch: fetchSpy as any,
+          headers: { 'x-my-custom-header': 'custom-value' },
+        },
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/embeddings', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+          'x-my-custom-header': 'custom-value',
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
We need to support supplying custom headers. Some of the APIs have extra configuration supplied through headers. For example, OpenAI sends organization id in header, or cohere+anthropic can specify API versions in headers. While we could make explicit options for these (we already did with Anthropic version), there will continue to be cases not handled by our API where extra headers are needed.