### PR TITLE
Add support for aborting fetch requests

### DIFF
--- a/docs/documentation/models/anthropic-completion.md
+++ b/docs/documentation/models/anthropic-completion.md
@@ -31,6 +31,7 @@ declare class AnthropicCompletion {
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns Anthropic completion. See Anthropic's documentation for /v1/complete.
  */
 declare function run(
@@ -55,6 +56,7 @@ declare function run(
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -79,6 +81,7 @@ declare function streamBytes(
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -103,6 +106,7 @@ declare function stream(
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/cohere-embedding.md
+++ b/docs/documentation/models/cohere-embedding.md
@@ -27,6 +27,7 @@ declare class CohereEmbedding {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/embed.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns An object consisting of the text embeddings and other metadata. See Cohere's documentation for /v1/embed.
  */
 declare function run(

--- a/docs/documentation/models/cohere-generation.md
+++ b/docs/documentation/models/cohere-generation.md
@@ -30,6 +30,7 @@ declare class CohereGeneration {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns Cohere completion. See Cohere's documentation for /v1/generate.
  */
 declare function run(
@@ -52,6 +53,7 @@ declare function run(
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -74,6 +76,7 @@ declare function streamBytes(
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -96,6 +99,7 @@ declare function stream(
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/huggingface-text-generation.md
+++ b/docs/documentation/models/huggingface-text-generation.md
@@ -26,10 +26,11 @@ declare class HuggingFaceTextGeneration {
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns The response body from HF. See their documentation linked above for details
  */
 declare function run(
@@ -48,10 +49,11 @@ declare function run(
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -76,10 +78,11 @@ declare function streamBytes(
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API
  */
 declare function stream(
@@ -99,10 +102,11 @@ declare function stream(
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(
@@ -126,7 +130,7 @@ const response = await HuggingFaceTextGeneration.stream(
     },
   },
   {
-    accessToken: process.env.HF_TOKEN!,
+    apiKey: process.env.HUGGINGFACE_ACCESS_TOKEN!,
     apiUrl: 'https://styuqm054heenl9w.us-east-1.aws.endpoints.huggingface.cloud',
   }
 );

--- a/docs/documentation/models/openai-chat.md
+++ b/docs/documentation/models/openai-chat.md
@@ -30,6 +30,7 @@ declare class OpenAIChat {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns OpenAI chat completion. See OpenAI's documentation for /v1/chat/completions.
  */
 declare function run(
@@ -52,6 +53,7 @@ declare function run(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -74,6 +76,7 @@ declare function streamBytes(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -96,6 +99,7 @@ declare function stream(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/openai-completion.md
+++ b/docs/documentation/models/openai-completion.md
@@ -30,6 +30,7 @@ declare class OpenAICompletion {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns OpenAI completion. See OpenAI's documentation for /v1/completions.
  */
 declare function run(
@@ -52,6 +53,7 @@ declare function run(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
@@ -74,6 +76,7 @@ declare function streamBytes(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 declare function stream(
@@ -96,6 +99,7 @@ declare function stream(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/docs/documentation/models/openai-embedding.md
+++ b/docs/documentation/models/openai-embedding.md
@@ -27,6 +27,7 @@ declare class OpenAIEmbedding {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns An object consisting of the text embeddings and other metadata. See OpenAI's documentation for /v1/embeddings.
  */
 declare function run(

--- a/docs/guides/models/getting-started.md
+++ b/docs/guides/models/getting-started.md
@@ -213,7 +213,8 @@ The run and stream functions support overriding or customizing some behavior. Fo
 
 1. Supplying a custom `apiUrl` to point to a different API implementation, e.g., proxy or otherwise compatible API.
 2. Supplying custom request headers.
-3. Supplying a custom `fetch` implementation, which could act as a client-side proxy, add logging, or otherwise customize request behavior.
+3. Supplying an abort signal which enables aborting the underlying fetch request.
+4. Supplying a custom `fetch` implementation, which could act as a client-side proxy, add logging, or otherwise customize request behavior.
 
 For example:
 
@@ -224,7 +225,8 @@ const response = await CohereGeneration.stream({ /* ... */ }, {
   apiUrl: 'https://api.example.com/v1/generate',
   headers: {
     'x-my-custom-header': 'custom-value',
-  }
+  },
+  signal: AbortSignal.timeout(5000),
 });
 ```
 

--- a/packages/models/src/anthropic/completion.ts
+++ b/packages/models/src/anthropic/completion.ts
@@ -20,6 +20,7 @@ export namespace AnthropicCompletionTypes {
     version?: string;
     fetch?: typeof fetch;
     headers?: Record<string, string>;
+    signal?: AbortSignal;
   };
 
   type Completion = {
@@ -80,6 +81,7 @@ function headers(apiKey?: string, version?: string, customHeaders?: Record<strin
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns Anthropic completion. See Anthropic's documentation for /v1/complete.
  */
 async function run(
@@ -92,6 +94,7 @@ async function run(
     headers: headers(options.apiKey, options.version, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();
@@ -110,6 +113,7 @@ async function run(
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -122,6 +126,7 @@ async function streamBytes(
     headers: headers(options.apiKey, options.version, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   if (!response.body) {
@@ -148,6 +153,7 @@ function noop(chunk: AnthropicCompletionTypes.Chunk) {
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -175,6 +181,7 @@ function chunkToToken(chunk: AnthropicCompletionTypes.Chunk): string {
  * @param options.version The Anthropic API version. Defaults to 2023-06-01. Note that older versions are not currently supported.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/cohere/embedding.ts
+++ b/packages/models/src/cohere/embedding.ts
@@ -39,6 +39,7 @@ export namespace CohereEmbeddingTypes {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/embed.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns An object consisting of the text embeddings and other metadata. See Cohere's documentation for /v1/embed.
  */
 async function run(
@@ -51,6 +52,7 @@ async function run(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify(request),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();

--- a/packages/models/src/cohere/generation.ts
+++ b/packages/models/src/cohere/generation.ts
@@ -73,6 +73,7 @@ export namespace CohereGenerationTypes {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns Cohere completion. See Cohere's documentation for /v1/generate.
  */
 async function run(
@@ -85,6 +86,7 @@ async function run(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();
@@ -101,6 +103,7 @@ async function run(
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -113,6 +116,7 @@ async function streamBytes(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   if (!response.body) {
@@ -137,6 +141,7 @@ function noop(chunk: CohereGenerationTypes.Chunk) {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -162,6 +167,7 @@ function chunkToToken(chunk: CohereGenerationTypes.Chunk) {
  * @param options.apiUrl The url of the Cohere (or compatible) API. Defaults to https://api.cohere.ai/v1/generate.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/cohere/shared.ts
+++ b/packages/models/src/cohere/shared.ts
@@ -3,6 +3,7 @@ export type SharedRequestOptions = {
   apiUrl?: string;
   fetch?: typeof fetch;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 };
 
 export function headers(apiKey?: string, customHeaders?: Record<string, string>) {

--- a/packages/models/src/huggingface/text-generation.ts
+++ b/packages/models/src/huggingface/text-generation.ts
@@ -7,14 +7,14 @@ import { HttpError, isHttpError, POST } from '@axflow/models/shared';
 const HUGGING_FACE_MODEL_API_URL = 'https://api-inference.huggingface.co/models/';
 const HUGGING_FACE_STOP_TOKEN = '</s>';
 
-function headers(accessToken?: string, customHeaders?: Record<string, string>) {
+function headers(apiKey?: string, customHeaders?: Record<string, string>) {
   const headers: Record<string, string> = {
     accept: 'application/json',
     ...customHeaders,
     'content-type': 'application/json',
   };
-  if (typeof accessToken === 'string') {
-    headers.authorization = `Bearer ${accessToken}`;
+  if (typeof apiKey === 'string') {
+    headers.authorization = `Bearer ${apiKey}`;
   }
   return headers;
 }
@@ -43,10 +43,11 @@ export namespace HuggingFaceTextGenerationTypes {
   };
 
   export type RequestOptions = {
-    accessToken?: string;
+    apiKey?: string;
     apiUrl?: string;
     fetch?: typeof fetch;
     headers?: Record<string, string>;
+    signal?: AbortSignal;
   };
 
   export type GeneratedText = {
@@ -81,10 +82,11 @@ export namespace HuggingFaceTextGenerationTypes {
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns The response body from HF. See their documentation linked above for details
  */
 async function run(
@@ -93,12 +95,13 @@ async function run(
 ): Promise<HuggingFaceTextGenerationTypes.Response> {
   const url = options.apiUrl || HUGGING_FACE_MODEL_API_URL + request.model;
 
-  const headers_ = headers(options.accessToken, options.headers);
+  const headers_ = headers(options.apiKey, options.headers);
   const body = JSON.stringify({ ...request, stream: false });
   const response = await POST(url, {
     headers: headers_,
     body,
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();
@@ -111,10 +114,11 @@ async function run(
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -123,13 +127,14 @@ async function streamBytes(
 ): Promise<ReadableStream<Uint8Array>> {
   const url = options.apiUrl || HUGGING_FACE_MODEL_API_URL + request.model;
 
-  const headers_ = headers(options.accessToken, options.headers);
+  const headers_ = headers(options.apiKey, options.headers);
   const body = JSON.stringify({ ...request, stream: true });
   try {
     const response = await POST(url, {
       headers: headers_,
       body,
       fetch: options.fetch,
+      signal: options.signal,
     });
 
     if (!response.body) {
@@ -186,10 +191,11 @@ function chunkToToken(chunk: HuggingFaceTextGenerationTypes.Chunk) {
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API
  */
 async function stream(
@@ -208,10 +214,11 @@ async function stream(
  *
  * @param request The request body sent to HF. See their documentation linked above for details
  * @param options
- * @param options.accessToken The HuggingFace access token. If not provided, requests will be throttled
+ * @param options.apiKey The HuggingFace access token. If not provided, requests will be throttled
  * @param options.apiUrl The HuggingFace API URL. Defaults to https://api-inference.huggingface.co/models/
  * @param options.fetch The fetch implementation to use. Defaults to globalThis.fetch
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/openai/chat.ts
+++ b/packages/models/src/openai/chat.ts
@@ -90,6 +90,7 @@ export namespace OpenAIChatTypes {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns OpenAI chat completion. See OpenAI's documentation for /v1/chat/completions.
  */
 async function run(
@@ -102,6 +103,7 @@ async function run(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();
@@ -118,6 +120,7 @@ async function run(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -130,6 +133,7 @@ async function streamBytes(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   if (!response.body) {
@@ -154,6 +158,7 @@ function noop(chunk: OpenAIChatTypes.Chunk) {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -179,6 +184,7 @@ function chunkToToken(chunk: OpenAIChatTypes.Chunk) {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/chat/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/openai/completion.ts
+++ b/packages/models/src/openai/completion.ts
@@ -72,6 +72,7 @@ export namespace OpenAICompletionTypes {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns OpenAI completion. See OpenAI's documentation for /v1/completions.
  */
 async function run(
@@ -84,6 +85,7 @@ async function run(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: false }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();
@@ -100,6 +102,7 @@ async function run(
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
@@ -112,6 +115,7 @@ async function streamBytes(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify({ ...request, stream: true }),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   if (!response.body) {
@@ -136,6 +140,7 @@ function noop(chunk: OpenAICompletionTypes.Chunk) {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of objects representing each chunk from the API.
  */
 async function stream(
@@ -161,6 +166,7 @@ function chunkToToken(chunk: OpenAICompletionTypes.Chunk) {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/completions.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(

--- a/packages/models/src/openai/embedding.ts
+++ b/packages/models/src/openai/embedding.ts
@@ -42,6 +42,7 @@ export namespace OpenAIEmbeddingTypes {
  * @param options.apiUrl The url of the OpenAI (or compatible) API. Defaults to https://api.openai.com/v1/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
  * @returns An object consisting of the text embeddings and other metadata. See OpenAI's documentation for /v1/embeddings.
  */
 async function run(
@@ -54,6 +55,7 @@ async function run(
     headers: headers(options.apiKey, options.headers),
     body: JSON.stringify(request),
     fetch: options.fetch,
+    signal: options.signal,
   });
 
   return response.json();

--- a/packages/models/src/openai/shared.ts
+++ b/packages/models/src/openai/shared.ts
@@ -3,6 +3,7 @@ export type SharedRequestOptions = {
   apiUrl?: string;
   fetch?: typeof fetch;
   headers?: Record<string, string>;
+  signal?: AbortSignal;
 };
 
 export function headers(apiKey?: string, customHeaders?: Record<string, string>) {

--- a/packages/models/test/anthropic/completion.test.ts
+++ b/packages/models/test/anthropic/completion.test.ts
@@ -69,7 +69,9 @@ describe('anthropic completion', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           completion: ' Hello!',
@@ -90,6 +92,7 @@ describe('anthropic completion', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -104,6 +107,7 @@ describe('anthropic completion', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });
@@ -158,7 +162,9 @@ describe('anthropic completion', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingCompletionResponse),
       });
@@ -173,6 +179,7 @@ describe('anthropic completion', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -187,6 +194,7 @@ describe('anthropic completion', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });

--- a/packages/models/test/cohere/embedding.test.ts
+++ b/packages/models/test/cohere/embedding.test.ts
@@ -42,7 +42,9 @@ describe('cohere embedding', () => {
       expect(bodyArgument).toEqual({ texts: ['How can I deploy to fly.io?'] });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           id: '2dac6b8b-2038-410d-9674-8b5e1b4eef47',
@@ -58,6 +60,7 @@ describe('cohere embedding', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -71,6 +74,7 @@ describe('cohere embedding', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });

--- a/packages/models/test/cohere/generation.test.ts
+++ b/packages/models/test/cohere/generation.test.ts
@@ -74,7 +74,9 @@ describe('cohere generation', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           id: 'a427751b-776f-49a8-b078-3b36acd206d1',
@@ -98,6 +100,7 @@ describe('cohere generation', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -111,6 +114,7 @@ describe('cohere generation', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });
@@ -162,7 +166,9 @@ describe('cohere generation', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingGenerationResponse),
       });
@@ -176,6 +182,7 @@ describe('cohere generation', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -189,6 +196,7 @@ describe('cohere generation', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });

--- a/packages/models/test/huggingface/text-generation.test.ts
+++ b/packages/models/test/huggingface/text-generation.test.ts
@@ -21,6 +21,8 @@ describe('huggingface textGeneration task', () => {
 
   describe('run', () => {
     it('executes a generation', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: [
           {
@@ -40,9 +42,10 @@ describe('huggingface textGeneration task', () => {
           },
         },
         {
-          accessToken: 'hf_not-real',
+          apiKey: 'hf_not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
       expect(response).toEqual([
@@ -64,6 +67,7 @@ describe('huggingface textGeneration task', () => {
           'x-my-custom-header': 'custom-value',
           'content-type': 'application/json',
         },
+        signal: abortController.signal,
       });
 
       const args = fetchSpy.mock.lastCall as any;
@@ -81,7 +85,9 @@ describe('huggingface textGeneration task', () => {
   });
 
   describe('stream', () => {
-    it('executes a streaming completion)', async () => {
+    it('executes a streaming completion', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingGenerationResponse),
       });
@@ -97,7 +103,7 @@ describe('huggingface textGeneration task', () => {
             temperature: 0.1,
           },
         },
-        { accessToken: 'hf_123', fetch: fetchSpy as any },
+        { apiKey: 'hf_123', fetch: fetchSpy as any, signal: abortController.signal },
       );
 
       let totalResp = '';
@@ -117,6 +123,7 @@ describe('huggingface textGeneration task', () => {
             authorization: 'Bearer hf_123',
             'content-type': 'application/json',
           },
+          signal: abortController.signal,
         },
       );
       const args = fetchSpy.mock.lastCall as any;
@@ -153,7 +160,7 @@ describe('huggingface textGeneration task', () => {
         },
       },
       {
-        accessToken: 'hf_123',
+        apiKey: 'hf_123',
         fetch: fetchSpy as any,
         apiUrl: 'https://custom.api.endpoint',
         headers: { 'x-my-custom-header': 'custom-value' },
@@ -206,7 +213,7 @@ describe('huggingface textGeneration task', () => {
           model: 'google/flan-t5-xxl',
           inputs: 'Whats the best way to make a chicken pesto dish?',
         },
-        { accessToken: 'hf_nope', fetch: fetchSpy as any },
+        { apiKey: 'hf_nope', fetch: fetchSpy as any },
       );
       let words = '';
       for await (const chunk of StreamToIterable(response)) {
@@ -254,7 +261,7 @@ describe('huggingface textGeneration task', () => {
             max_new_tokens: 250,
           },
         },
-        { accessToken: 'hf_123', fetch: fetchSpy as any, apiUrl: 'https://custom.api.endpoint' },
+        { apiKey: 'hf_123', fetch: fetchSpy as any, apiUrl: 'https://custom.api.endpoint' },
       );
 
       let totalResp = '';

--- a/packages/models/test/openai/chat.test.ts
+++ b/packages/models/test/openai/chat.test.ts
@@ -76,7 +76,9 @@ describe('openai chat', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           id: 'chatcmpl-7q9iFa9eplmD2n3hGPwJ6iBLlUQkY',
@@ -109,6 +111,7 @@ describe('openai chat', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -122,6 +125,7 @@ describe('openai chat', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });
@@ -179,7 +183,9 @@ describe('openai chat', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingChatResponse),
       });
@@ -195,6 +201,7 @@ describe('openai chat', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -208,6 +215,7 @@ describe('openai chat', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });

--- a/packages/models/test/openai/completion.test.ts
+++ b/packages/models/test/openai/completion.test.ts
@@ -75,7 +75,9 @@ describe('openai chat', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           id: 'cmpl-7qQ4UuIH02BRy3yAN71b8KeHxN19p',
@@ -104,6 +106,7 @@ describe('openai chat', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -117,6 +120,7 @@ describe('openai chat', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });
@@ -172,7 +176,9 @@ describe('openai chat', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         body: createUnpredictableByteStream(streamingChatResponse),
       });
@@ -187,6 +193,7 @@ describe('openai chat', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -200,6 +207,7 @@ describe('openai chat', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });

--- a/packages/models/test/openai/embedding.test.ts
+++ b/packages/models/test/openai/embedding.test.ts
@@ -48,7 +48,9 @@ describe('openai embedding', () => {
       });
     });
 
-    it('can supply custom headers', async () => {
+    it('can supply additional options', async () => {
+      const abortController = new AbortController();
+
       const fetchSpy = createFakeFetch({
         json: {
           object: 'list',
@@ -67,6 +69,7 @@ describe('openai embedding', () => {
           apiKey: 'sk-not-real',
           fetch: fetchSpy as any,
           headers: { 'x-my-custom-header': 'custom-value' },
+          signal: abortController.signal,
         },
       );
 
@@ -80,6 +83,7 @@ describe('openai embedding', () => {
           'content-type': 'application/json',
           'x-my-custom-header': 'custom-value',
         },
+        signal: abortController.signal,
       });
     });
   });


### PR DESCRIPTION
In JS, you can explicitly abort a fetch request using an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). This enables behavior like setting timeouts for requests, or perhaps user-controlled behavior where they can choose to stop a long-running request.

A simple timeout example might look like:

```ts
OpenAIChat.run({ /* .. .*/ }, { /* .. .*/, signal: AbortSignal.timeout(5000) });
```

Or more involved user-controlled behavior might look like:

```ts
const controller = new AbortController();
OpenAIChat.run({ /* .. .*/ }, { /* .. .*/, signal: controller.signal });

<button onClick={() => controller.abort()}>Cancel request</button>
```

## Before merge

- [ ] Needs more thorough testing. In particular, what is the behavior of our streaming code when a request is aborted mid stream?