### PR TITLE
Support Ollama

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,8 @@ export default defineConfig({
                   },
                   { text: 'CohereGeneration', link: '/documentation/models/cohere-generation' },
                   { text: 'CohereEmbedding', link: '/documentation/models/cohere-embedding' },
+                  { text: 'OllamaGeneration', link: '/documentation/models/ollama-generation' },
+                  { text: 'OllamaEmbedding', link: '/documentation/models/ollama-embedding' },
                   { text: 'React', link: '/documentation/models/react' },
                   { text: 'Node', link: '/documentation/models/node' },
                   { text: 'Shared', link: '/documentation/models/shared' },

--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -21,6 +21,7 @@ npm i @axflow/models
 - ✅ Cohere and Cohere-compatible Generation and Embedding models
 - ✅ Anthropic and Anthropic-compatible Completion models
 - ✅ HuggingFace text generation inference API and Inference Endpoints
+- ✅ Ollama.ai models running locally
 - Google PaLM models (coming soon)
 - Azure OpenAI (coming soon)
 - Replicate (coming soon)
@@ -36,6 +37,7 @@ View the [Guides](/guides) or the reference:
 - [@axflow/models/cohere/generation](/documentation/models/cohere-generation)
 - [@axflow/models/cohere/embedding](/documentation/models/cohere-embedding)
 - [@axflow/models/huggingface/text-generation](/documentation/models/huggingface-text-generation)
+- [@axflow/models/ollama/generation](/documentation/models/ollama-generation)
 - [@axflow/models/react](/documentation/models/react)
 - [@axflow/models/node](/documentation/models/node)
 - # [@axflow/models/shared](/documentation/models/shared)

--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -21,7 +21,7 @@ npm i @axflow/models
 - ✅ Cohere and Cohere-compatible Generation and Embedding models
 - ✅ Anthropic and Anthropic-compatible Completion models
 - ✅ HuggingFace text generation inference API and Inference Endpoints
-- ✅ Ollama.ai models running locally
+- ✅ Ollama.ai models running generation or embedding generation
 - Google PaLM models (coming soon)
 - Azure OpenAI (coming soon)
 - Replicate (coming soon)
@@ -38,6 +38,7 @@ View the [Guides](/guides) or the reference:
 - [@axflow/models/cohere/embedding](/documentation/models/cohere-embedding)
 - [@axflow/models/huggingface/text-generation](/documentation/models/huggingface-text-generation)
 - [@axflow/models/ollama/generation](/documentation/models/ollama-generation)
+- [@axflow/models/ollama/embedding](/documentation/models/ollama-embedding)
 - [@axflow/models/react](/documentation/models/react)
 - [@axflow/models/node](/documentation/models/node)
 - # [@axflow/models/shared](/documentation/models/shared)

--- a/docs/documentation/models/ollama-embedding.md
+++ b/docs/documentation/models/ollama-embedding.md
@@ -1,0 +1,36 @@
+# @axflow/models/ollama/embedding
+
+Interface with [Ollama's Embeddings API](https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings) using this module.
+
+```ts
+import { OllamaEmbedding } from '@axflow/models/ollama/embedding';
+import type { OllamaEmbeddingTypes } from '@axflow/models/ollama/embedding';
+```
+
+```ts
+declare class OllamaEmbedding {
+  static run: typeof run;
+}
+```
+
+## `run`
+
+```ts
+/**
+ * Calculate text embeddings using a model served by Ollama
+ *
+ * @see https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings
+ *
+ * @param request The request body sent to Ollama. It contains the prompt, the model, and some options
+ * @param options
+ * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns An object consisting of the text embeddings for the given prompt.
+ */
+declare function run(
+  request: OllamaEmbeddingTypes.Request,
+  options: OllamaEmbeddingTypes.RequestOptions
+): Promise<OllamaEmbeddingTypeOllamaEmbeddingTypes.Response>;
+```

--- a/docs/documentation/models/ollama-embedding.md
+++ b/docs/documentation/models/ollama-embedding.md
@@ -17,13 +17,13 @@ declare class OllamaEmbedding {
 
 ```ts
 /**
- * Calculate text embeddings using a model served by Ollama
+ * Calculate text embeddings using a model served by Ollama.
  *
  * @see https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings
  *
- * @param request The request body sent to Ollama. It contains the prompt, the model, and some options
+ * @param request The request body sent to Ollama. It contains the prompt, the model, and some options.
  * @param options
- * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings
+ * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
  * @param options.signal An AbortSignal that can be used to abort the fetch request.

--- a/docs/documentation/models/ollama-generation.md
+++ b/docs/documentation/models/ollama-generation.md
@@ -1,0 +1,86 @@
+# @axflow/models/ollama/generation
+
+Interface with [local ollama models](https://ollama.ai) using this module.
+
+```ts
+import { OllamaGeneration } from '@axflow/models/ollama/generation';
+import type { OllamaGenerationTypes } from '@axflow/models/ollama/generation';
+```
+
+```ts
+declare class OllamaGeneration {
+  static stream: typeof stream;
+  static streamBytes: typeof streamBytes;
+  static streamTokens: typeof streamTokens;
+}
+```
+
+_Note: Ollama only provides streaming APIs, so Axflow does the same._
+
+## `streamBytes`
+
+```ts
+/**
+ * Stream a generation against an ollama serving endpoint. Return a stream of bytes.
+ * Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns a stream of bytes directly from the API
+ */
+declare function streamBytes(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions
+): Promise<ReadableStream<Uint8Array>>;
+```
+
+## `stream`
+
+```ts
+/**
+ * Stream a generation against an ollama serving endpoint, return javascript objects.
+ *
+ * Example chunk:
+ *   {
+ *     token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
+ *     generated_text: null,
+ *     details: null
+ *   }
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns a stream of objects representing each chunk from the api
+ */
+declare function stream(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions
+): Promise<ReadableStream<OllamaGenerationTypes.Chunk>>;
+```
+
+## `streamTokens`
+
+```ts
+/**
+ * Stream a generation against an ollama serving endpoint, return only the text tokens
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns A stream of tokens from the API.
+ */
+declare function streamTokens(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions
+): Promise<ReadableStream<string>>;
+```

--- a/docs/documentation/models/ollama-generation.md
+++ b/docs/documentation/models/ollama-generation.md
@@ -15,7 +15,9 @@ declare class OllamaGeneration {
 }
 ```
 
-_Note: Ollama only provides streaming APIs, so Axflow does the same._
+::: info
+Ollama only provides streaming APIs, so Axflow does the same.
+:::
 
 ## `streamBytes`
 

--- a/docs/documentation/models/ollama-generation.md
+++ b/docs/documentation/models/ollama-generation.md
@@ -24,13 +24,13 @@ _Note: Ollama only provides streaming APIs, so Axflow does the same._
  * Stream a generation against an ollama serving endpoint. Return a stream of bytes.
  * Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
- * @returns a stream of bytes directly from the API
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
+ * @returns A stream of bytes directly from the API.
  */
 declare function streamBytes(
   request: OllamaGenerationTypes.Request,
@@ -51,13 +51,13 @@ declare function streamBytes(
  *     details: null
  *   }
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
- * @returns a stream of objects representing each chunk from the api
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
+ * @returns A stream of objects representing each chunk from the api.
  */
 declare function stream(
   request: OllamaGenerationTypes.Request,
@@ -69,14 +69,14 @@ declare function stream(
 
 ```ts
 /**
- * Stream a generation against an ollama serving endpoint, return only the text tokens
+ * Stream a generation against an ollama serving endpoint, return only the text tokens.
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 declare function streamTokens(

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -21,7 +21,7 @@ npm i @axflow/models
 - ✅ Cohere and Cohere-compatible Generation and Embedding models
 - ✅ Anthropic and Anthropic-compatible Completion models
 - ✅ HuggingFace text generation inference API and Inference Endpoints
-- HuggingFace (coming soon)
+- ✅ Ollama.ai models running locally
 - Google PaLM models (coming soon)
 - Azure OpenAI (coming soon)
 - Replicate (coming soon)

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -37,6 +37,8 @@ View the [Guides](https://docs.axflow.dev/guides) or the reference:
 - [@axflow/models/cohere/generation](https://docs.axflow.dev/documentation/models/cohere-generation.html)
 - [@axflow/models/cohere/embedding](https://docs.axflow.dev/documentation/models/cohere-embedding.html)
 - [@axflow/models/huggingface/text-generation](https://docs.axflow.dev/documentation/models/huggingface-text-generation.html)
+- [@axflow/models/ollama/generation](https://docs.axflow.dev/documentation/models/ollama-generation.html)
+- [@axflow/models/ollama/embedding](https://docs.axflow.dev/documentation/models/ollama-embedding.html)
 - [@axflow/models/react](https://docs.axflow.dev/documentation/models/react.html)
 - [@axflow/models/node](https://docs.axflow.dev/documentation/models/node.html)
 - [@axflow/models/shared](https://docs.axflow.dev/documentation/models/shared.html)

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -142,6 +142,18 @@
       "module": "./dist/cohere/embedding.mjs",
       "require": "./dist/cohere/embedding.js"
     },
+    "./ollama/generation": {
+      "types": "./dist/ollama/generation.d.ts",
+      "import": "./dist/ollama/generation.mjs",
+      "module": "./dist/ollama/generation.mjs",
+      "require": "./dist/ollama/generation.js"
+    },
+    "./ollama/embedding": {
+      "types": "./dist/ollama/embedding.d.ts",
+      "import": "./dist/ollama/embedding.mjs",
+      "module": "./dist/ollama/embedding.mjs",
+      "require": "./dist/ollama/embedding.js"
+    },
     "./huggingface/text-generation": {
       "types": "./dist/huggingface/text-generation.d.ts",
       "import": "./dist/huggingface/text-generation.mjs",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -15,6 +15,7 @@
     "openai",
     "anthropic",
     "cohere",
+    "ollama",
     "palm",
     "llama2",
     "embeddings",
@@ -89,6 +90,12 @@
       ],
       "cohere/embedding": [
         "./dist/cohere/embedding.d.ts"
+      ],
+      "ollama/generation": [
+        "./dist/ollama/generation.d.ts"
+      ],
+      "ollama/embedding": [
+        "./dist/ollama/embedding.d.ts"
       ],
       "react": [
         "./dist/react/index.d.ts"

--- a/packages/models/src/ollama/embedding.ts
+++ b/packages/models/src/ollama/embedding.ts
@@ -18,19 +18,19 @@ export namespace OllamaEmbeddingTypes {
   };
 
   export type Response = {
-    // Note: their documentation is wrong, this is purposefully singular
+    // Note: their documentation is wrong, this is purposefully singular.
     embedding: number[];
   };
 }
 
 /**
- * Calculate text embeddings using a model served by Ollama
+ * Calculate text embeddings using a model served by Ollama.
  *
  * @see https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings
  *
- * @param request The request body sent to Ollama. It contains the prompt, the model, and some options
+ * @param request The request body sent to Ollama. It contains the prompt, the model, and some options.
  * @param options
- * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings
+ * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings.
  * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
  * @param options.headers Optionally add additional HTTP headers to the request.
  * @param options.signal An AbortSignal that can be used to abort the fetch request.

--- a/packages/models/src/ollama/embedding.ts
+++ b/packages/models/src/ollama/embedding.ts
@@ -1,0 +1,60 @@
+import { POST } from '@axflow/models/shared';
+import { OllamaModelOptions } from './shared';
+
+const OLLAMA_EMBEDDING_URL = 'http://127.0.0.1:11434/api/embeddings';
+
+export namespace OllamaEmbeddingTypes {
+  export type Request = {
+    model: string;
+    prompt: string;
+    options?: OllamaModelOptions;
+  };
+
+  export type RequestOptions = {
+    apiUrl?: string;
+    fetch?: typeof fetch;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  };
+
+  export type Response = {
+    // Note: their documentation is wrong, this is purposefully singular
+    embedding: number[];
+  };
+}
+
+/**
+ * Calculate text embeddings using a model served by Ollama
+ *
+ * @see https://github.com/jmorganca/ollama/blob/main/docs/api.md#generate-embeddings
+ *
+ * @param request The request body sent to Ollama. It contains the prompt, the model, and some options
+ * @param options
+ * @param options.apiUrl The url where the ollama embedding endpoint is served. Defaults to http://127.0.0.1:11434/api/embeddings
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns An object consisting of the text embeddings for the given prompt.
+ */
+async function run(
+  request: OllamaEmbeddingTypes.Request,
+  options: OllamaEmbeddingTypes.RequestOptions,
+): Promise<OllamaEmbeddingTypes.Response> {
+  const url = options.apiUrl || OLLAMA_EMBEDDING_URL;
+
+  const response = await POST(url, {
+    headers: options.headers,
+    body: JSON.stringify(request),
+    fetch: options.fetch,
+    signal: options.signal,
+  });
+
+  return response.json();
+}
+
+/**
+ * An object that encapsulates methods for calling the Ollama Embeddings API.
+ */
+export class OllamaEmbedding {
+  static run = run;
+}

--- a/packages/models/src/ollama/embedding.ts
+++ b/packages/models/src/ollama/embedding.ts
@@ -43,7 +43,7 @@ async function run(
   const url = options.apiUrl || OLLAMA_EMBEDDING_URL;
 
   const response = await POST(url, {
-    headers: options.headers,
+    headers: options.headers || {},
     body: JSON.stringify(request),
     fetch: options.fetch,
     signal: options.signal,

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -31,7 +31,7 @@ export namespace OllamaGenerationTypes {
     response: string;
     done: boolean;
     // Below are fields that are present only when done is true
-    // All durations are in nanoseconds, per the ollama documentation
+    // All durations are in nanoseconds, per the ollama documentation.
     context?: Array<number>;
     total_duration?: number;
     load_duration?: number;
@@ -46,13 +46,13 @@ export namespace OllamaGenerationTypes {
  * Stream a generation against an ollama serving endpoint. Return a stream of bytes.
  * Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
- * @returns a stream of bytes directly from the API
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
+ * @returns A stream of bytes directly from the API.
  */
 async function streamBytes(
   request: OllamaGenerationTypes.Request,
@@ -107,13 +107,13 @@ function chunkToToken(chunk: OllamaGenerationTypes.Chunk) {
  *     details: null
  *   }
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
- * @returns a stream of objects representing each chunk from the api
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
+ * @returns A stream of objects representing each chunk from the api.
  */
 async function stream(
   request: OllamaGenerationTypes.Request,
@@ -124,14 +124,14 @@ async function stream(
 }
 
 /**
- * Stream a generation against an ollama serving endpoint, return only the text tokens
+ * Stream a generation against an ollama serving endpoint, return only the text tokens.
  *
- * @param request the request body containing the model, prompt, and options.
+ * @param request The request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
- * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
- * @param options.headers optionally add additional http headers to the request.
- * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @param options.apiurl The ollama serving url. defaults to http://127.0.0.1:11343.
+ * @param options.fetch The fetch implementation to use. defaults to globalthis.fetch.
+ * @param options.headers Optionally add additional http headers to the request.
+ * @param options.signal An abortsignal that can be used to abort the fetch request.
  * @returns A stream of tokens from the API.
  */
 async function streamTokens(
@@ -143,7 +143,7 @@ async function streamTokens(
 }
 
 /**
- * An object that encapsulates methods for calling the HF inference API
+ * An object that encapsulates methods for calling the HF inference API.
  */
 export class OllamaGeneration {
   static streamBytes = streamBytes;
@@ -176,16 +176,16 @@ class OllamaDecoderStream<T> extends TransformStream<Uint8Array, T> {
       const chunk = decoder.decode(bytes);
 
       for (let i = 0, len = chunk.length; i < len; ++i) {
-        // Ollama's response format is xd-ndjson: each line is a parsable JSON object
+        // Ollama's response format is xd-ndjson: each line is a parsable JSON object.
         const isSeparator = chunk[i] === '\n';
 
-        // Keep buffering unless we've hit the end of a data chunk
+        // Keep buffering unless we've hit the end of a data chunk.
         if (!isSeparator) {
           buffer.push(chunk[i]);
           continue;
         }
 
-        // Decode the object into the expected JSON type
+        // Decode the object into the expected JSON type.
         const parsedChunk = OllamaDecoderStream.parseChunk(buffer.join(''));
         if (parsedChunk) {
           controller.enqueue(map(parsedChunk));

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -6,10 +6,6 @@ import { OllamaModelOptions } from './shared';
 
 const OLLAMA_URL = 'http://127.0.0.1:11434/api/generate';
 
-function headers(customHeaders?: Record<string, string>) {
-  return { ...customHeaders };
-}
-
 export namespace OllamaGenerationTypes {
   // Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md#parameters
   export type Request = {
@@ -64,10 +60,9 @@ async function streamBytes(
 ): Promise<ReadableStream<Uint8Array>> {
   const url = options.apiUrl || OLLAMA_URL;
 
-  const headers_ = headers(options.headers);
   const body = JSON.stringify(request);
   const response = await POST(url, {
-    headers: headers_,
+    headers: options.headers,
     body,
     fetch: options.fetch,
     signal: options.signal,

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -81,9 +81,6 @@ async function streamBytes(
 
   const headers_ = headers(options.headers);
   const body = JSON.stringify(request);
-  console.log('ollama url', url);
-  console.log('ollama body', body);
-  console.log('ollama headers', headers_);
   const response = await POST(url, {
     headers: headers_,
     body,
@@ -175,19 +172,19 @@ export class OllamaGeneration {
 }
 
 class OllamaDecoderStream<T> extends TransformStream<Uint8Array, T> {
-  private static parseChunk(lines: string): OllamaGenerationTypes.Chunk | null {
+  private static parseChunk(line: string): OllamaGenerationTypes.Chunk | null {
     // We expect the Ollama chunks to be lines of parsable JSON directly.
-    lines = lines.trim();
+    line = line.trim();
 
     // Empty lines are ignored
-    if (lines.length === 0) {
+    if (line.length === 0) {
       return null;
     }
 
     try {
-      return JSON.parse(lines);
+      return JSON.parse(line);
     } catch (e) {
-      throw new Error(`Malformed streaming data from Ollama: ${JSON.stringify(lines)}`);
+      throw new Error(`Malformed streaming data from Ollama: ${JSON.stringify(line)}`);
     }
   }
 
@@ -199,7 +196,7 @@ class OllamaDecoderStream<T> extends TransformStream<Uint8Array, T> {
       const chunk = decoder.decode(bytes);
 
       for (let i = 0, len = chunk.length; i < len; ++i) {
-        // Ollama's response format is that each line is a parsable JSON object
+        // Ollama's response format is xd-ndjson: each line is a parsable JSON object
         const isSeparator = chunk[i] === '\n';
 
         // Keep buffering unless we've hit the end of a data chunk

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -62,7 +62,7 @@ async function streamBytes(
 
   const body = JSON.stringify(request);
   const response = await POST(url, {
-    headers: options.headers,
+    headers: options.headers || {},
     body,
     fetch: options.fetch,
     signal: options.signal,

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -67,7 +67,7 @@ export namespace OllamaGenerationTypes {
  *
  * @param request the request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
  * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
  * @param options.headers optionally add additional http headers to the request.
  * @param options.signal an abortsignal that can be used to abort the fetch request.
@@ -129,7 +129,7 @@ function chunkToToken(chunk: OllamaGenerationTypes.Chunk) {
  *
  * @param request the request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
  * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
  * @param options.headers optionally add additional http headers to the request.
  * @param options.signal an abortsignal that can be used to abort the fetch request.
@@ -148,7 +148,7 @@ async function stream(
  *
  * @param request the request body containing the model, prompt, and options.
  * @param options
- * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.apiurl the ollama serving url. defaults to http://127.0.0.1:11343
  * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
  * @param options.headers optionally add additional http headers to the request.
  * @param options.signal an abortsignal that can be used to abort the fetch request.

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -1,4 +1,5 @@
 import { HttpError, POST } from '@axflow/models/shared';
+import { OllamaModelOptions } from './shared';
 
 // Ollama.ai is an OSS engine to run open source models (like llama2, codellama) locally on macOS machines.
 // https://github.com/jmorganca/ollama/blob/main/docs/api.md#response
@@ -17,23 +18,7 @@ export namespace OllamaGenerationTypes {
     system?: string;
     template?: string;
     context?: string;
-    // Options docs: https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#parameter
-    options?: {
-      top_k?: number;
-      top_p?: number;
-      stop?: string;
-      temperature?: number;
-      repeat_penalty?: number;
-      repeat_last_n?: number;
-      num_threads?: number;
-      num_gpu?: number;
-      num_gqa?: number;
-      num_ctx?: number;
-      mirostat?: number;
-      mirostat_eta?: number;
-      mirostat_tau?: number;
-      tfs_z?: number;
-    };
+    options?: OllamaModelOptions;
   };
 
   export type RequestOptions = {

--- a/packages/models/src/ollama/generation.ts
+++ b/packages/models/src/ollama/generation.ts
@@ -1,0 +1,225 @@
+import { HttpError, POST } from '@axflow/models/shared';
+
+// Ollama.ai is an OSS engine to run open source models (like llama2, codellama) locally on macOS machines.
+// https://github.com/jmorganca/ollama/blob/main/docs/api.md#response
+
+const OLLAMA_URL = 'http://127.0.0.1:11434/api/generate';
+
+function headers(customHeaders?: Record<string, string>) {
+  return { ...customHeaders };
+}
+
+export namespace OllamaGenerationTypes {
+  // Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md#parameters
+  export type Request = {
+    model: string;
+    prompt: string;
+    system?: string;
+    template?: string;
+    context?: string;
+    // Options docs: https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#parameter
+    options?: {
+      top_k?: number;
+      top_p?: number;
+      stop?: string;
+      temperature?: number;
+      repeat_penalty?: number;
+      repeat_last_n?: number;
+      num_threads?: number;
+      num_gpu?: number;
+      num_gqa?: number;
+      num_ctx?: number;
+      mirostat?: number;
+      mirostat_eta?: number;
+      mirostat_tau?: number;
+      tfs_z?: number;
+    };
+  };
+
+  export type RequestOptions = {
+    apiUrl?: string;
+    fetch?: typeof fetch;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  };
+
+  // Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md#response
+  export type Chunk = {
+    model: string;
+    created_at: string;
+    response: string;
+    done: boolean;
+    // Below are fields that are present only when done is true
+    // All durations are in nanoseconds, per the ollama documentation
+    context?: Array<number>;
+    total_duration?: number;
+    load_duration?: number;
+    prompt_eval_count?: number;
+    prompt_eval_duration?: number;
+    eval_count?: number;
+    eval_duration?: number;
+  };
+}
+
+/**
+ * Stream a generation against an ollama serving endpoint. Return a stream of bytes.
+ * Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns a stream of bytes directly from the API
+ */
+async function streamBytes(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions,
+): Promise<ReadableStream<Uint8Array>> {
+  const url = options.apiUrl || OLLAMA_URL;
+
+  const headers_ = headers(options.headers);
+  const body = JSON.stringify(request);
+  console.log('ollama url', url);
+  console.log('ollama body', body);
+  console.log('ollama headers', headers_);
+  const response = await POST(url, {
+    headers: headers_,
+    body,
+    fetch: options.fetch,
+    signal: options.signal,
+  });
+
+  if (!response.body) {
+    throw new HttpError('Expected response body to be a ReadableStream', response);
+  }
+
+  return response.body;
+}
+
+function noop(chunk: OllamaGenerationTypes.Chunk) {
+  return chunk;
+}
+
+/*
+ * Return the text from a chunk. If the chunk is a stop token, don't return it to the user.
+ * Example ollama chunk:
+ *  {
+ *     "model":"llama2",
+ *     "created_at":"2023-09-18T20:08:59.480415Z",
+ *     "response":".",
+ *     "done":false
+ *   }
+ */
+function chunkToToken(chunk: OllamaGenerationTypes.Chunk) {
+  if (!chunk.done) {
+    return chunk.response;
+  } else {
+    return '';
+  }
+}
+
+/**
+ * Stream a generation against an ollama serving endpoint, return javascript objects.
+ *
+ * Example chunk:
+ *   {
+ *     token: { id: 11, text: ' and', logprob: -0.00002193451, special: false },
+ *     generated_text: null,
+ *     details: null
+ *   }
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns a stream of objects representing each chunk from the api
+ */
+async function stream(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions,
+): Promise<ReadableStream<OllamaGenerationTypes.Chunk>> {
+  const byteStream = await streamBytes(request, options);
+  return byteStream.pipeThrough(new OllamaDecoderStream(noop));
+}
+
+/**
+ * Stream a generation against an ollama serving endpoint, return only the text tokens
+ *
+ * @param request the request body containing the model, prompt, and options.
+ * @param options
+ * @param options.apiurl the ollama serving url. defaults to http://localhost:11343
+ * @param options.fetch the fetch implementation to use. defaults to globalthis.fetch
+ * @param options.headers optionally add additional http headers to the request.
+ * @param options.signal an abortsignal that can be used to abort the fetch request.
+ * @returns A stream of tokens from the API.
+ */
+async function streamTokens(
+  request: OllamaGenerationTypes.Request,
+  options: OllamaGenerationTypes.RequestOptions,
+): Promise<ReadableStream<string>> {
+  const byteStream = await streamBytes(request, options);
+  return byteStream.pipeThrough(new OllamaDecoderStream(chunkToToken));
+}
+
+/**
+ * An object that encapsulates methods for calling the HF inference API
+ */
+export class OllamaGeneration {
+  static streamBytes = streamBytes;
+  static stream = stream;
+  static streamTokens = streamTokens;
+}
+
+class OllamaDecoderStream<T> extends TransformStream<Uint8Array, T> {
+  private static parseChunk(lines: string): OllamaGenerationTypes.Chunk | null {
+    // We expect the Ollama chunks to be lines of parsable JSON directly.
+    lines = lines.trim();
+
+    // Empty lines are ignored
+    if (lines.length === 0) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(lines);
+    } catch (e) {
+      throw new Error(`Malformed streaming data from Ollama: ${JSON.stringify(lines)}`);
+    }
+  }
+
+  private static transformer<T>(map: (chunk: OllamaGenerationTypes.Chunk) => T) {
+    let buffer: string[] = [];
+    const decoder = new TextDecoder();
+
+    return (bytes: Uint8Array, controller: TransformStreamDefaultController<T>) => {
+      const chunk = decoder.decode(bytes);
+
+      for (let i = 0, len = chunk.length; i < len; ++i) {
+        // Ollama's response format is that each line is a parsable JSON object
+        const isSeparator = chunk[i] === '\n';
+
+        // Keep buffering unless we've hit the end of a data chunk
+        if (!isSeparator) {
+          buffer.push(chunk[i]);
+          continue;
+        }
+
+        // Decode the object into the expected JSON type
+        const parsedChunk = OllamaDecoderStream.parseChunk(buffer.join(''));
+        if (parsedChunk) {
+          controller.enqueue(map(parsedChunk));
+        }
+
+        buffer = [];
+      }
+    };
+  }
+
+  constructor(map: (chunk: OllamaGenerationTypes.Chunk) => T) {
+    super({ transform: OllamaDecoderStream.transformer(map) });
+  }
+}

--- a/packages/models/src/ollama/shared.ts
+++ b/packages/models/src/ollama/shared.ts
@@ -1,0 +1,17 @@
+// Options docs: https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#parameter
+export type OllamaModelOptions = {
+  top_k?: number;
+  top_p?: number;
+  stop?: string;
+  temperature?: number;
+  repeat_penalty?: number;
+  repeat_last_n?: number;
+  num_threads?: number;
+  num_gpu?: number;
+  num_gqa?: number;
+  num_ctx?: number;
+  mirostat?: number;
+  mirostat_eta?: number;
+  mirostat_tau?: number;
+  tfs_z?: number;
+};

--- a/packages/models/test/ollama/embedding.test.ts
+++ b/packages/models/test/ollama/embedding.test.ts
@@ -29,6 +29,7 @@ describe('ollama embedding', () => {
       expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:11434/api/embeddings', {
         body: expect.any(String),
         method: 'POST',
+        headers: {},
       });
 
       const args = fetchSpy.mock.lastCall as any;

--- a/packages/models/test/ollama/embedding.test.ts
+++ b/packages/models/test/ollama/embedding.test.ts
@@ -1,0 +1,40 @@
+import { createFakeFetch } from '../utils';
+import { OllamaEmbedding } from '../../src/ollama/embedding';
+
+describe('ollama embedding', () => {
+  describe('run', () => {
+    it('calculates embeddings', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          embedding: [
+            1.2192957401275635, -0.06883461773395538, 1.5663237571716309, 0.8945874571800232,
+            -1.438734531402588, -0.9785516858100891,
+          ],
+        },
+      });
+
+      const response = await OllamaEmbedding.run(
+        { model: 'llama2', prompt: 'How can I deploy to fly.io?' },
+        { fetch: fetchSpy as any },
+      );
+
+      expect(response).toEqual({
+        embedding: [
+          1.2192957401275635, -0.06883461773395538, 1.5663237571716309, 0.8945874571800232,
+          -1.438734531402588, -0.9785516858100891,
+        ],
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:11434/api/embeddings', {
+        body: expect.any(String),
+        method: 'POST',
+      });
+
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({ model: 'llama2', prompt: 'How can I deploy to fly.io?' });
+    });
+  });
+});

--- a/packages/models/test/ollama/generation.test.ts
+++ b/packages/models/test/ollama/generation.test.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import Path from 'node:path';
+import { OllamaGeneration } from '../../src/ollama/generation';
+import { StreamToIterable } from '../../src/shared';
+import { createFakeFetch, createUnpredictableByteStream } from '../utils';
+
+describe('ollama generation task', () => {
+  let streamingGenerationResponse: string;
+
+  beforeAll(async () => {
+    streamingGenerationResponse = await fs.readFile(
+      Path.join(__dirname, 'streaming-response.txt'),
+      { encoding: 'utf-8' },
+    );
+  });
+
+  describe('stream', () => {
+    it('executes a streaming completion', async () => {
+      const abortController = new AbortController();
+
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingGenerationResponse),
+      });
+
+      const response = await OllamaGeneration.stream(
+        {
+          model: 'llama2',
+          prompt: 'Write a haiku about TypeScript',
+        },
+        { fetch: fetchSpy as any, signal: abortController.signal },
+      );
+
+      let totalResp = '';
+      for await (const chunk of StreamToIterable(response)) {
+        // Don't append the last chunk's info, since it's aggregate stats
+        // without a response token.
+        if (!chunk.done) {
+          totalResp += chunk.response;
+        }
+      }
+
+      expect(totalResp).toEqual(` Sure! Here is a haiku about TypeScript:
+
+TypeScript's embrace
+Catches errors in bright light
+Programmer's bliss`);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:11434/api/generate', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {},
+        signal: abortController.signal,
+      });
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({
+        model: 'llama2',
+        prompt: 'Write a haiku about TypeScript',
+      });
+    });
+  });
+
+  describe('streamTokens', () => {
+    it('executes a streamTokens() properly)', async () => {
+      const abortController = new AbortController();
+
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingGenerationResponse),
+      });
+
+      const response = await OllamaGeneration.streamTokens(
+        {
+          model: 'llama2',
+          prompt: 'Write a haiku about TypeScript',
+        },
+        { fetch: fetchSpy as any, signal: abortController.signal },
+      );
+      let words = '';
+      for await (const chunk of StreamToIterable(response)) {
+        words += chunk;
+      }
+
+      expect(words).toEqual(` Sure! Here is a haiku about TypeScript:
+
+TypeScript's embrace
+Catches errors in bright light
+Programmer's bliss`);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:11434/api/generate', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {},
+        signal: abortController.signal,
+      });
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({
+        model: 'llama2',
+        prompt: 'Write a haiku about TypeScript',
+      });
+    });
+  });
+});

--- a/packages/models/test/ollama/streaming-response.txt
+++ b/packages/models/test/ollama/streaming-response.txt
@@ -1,0 +1,36 @@
+{"model":"llama2","created_at":"2023-09-18T22:33:15.028172Z","response":" Sure","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.059417Z","response":"!","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.089443Z","response":" Here","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.11952Z","response":" is","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.149101Z","response":" a","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.177954Z","response":" ha","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.207629Z","response":"iku","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.237046Z","response":" about","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.266912Z","response":" Type","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.296326Z","response":"Script","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.326015Z","response":":","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.355527Z","response":"\n","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.38568Z","response":"\n","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.415705Z","response":"Type","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.445453Z","response":"Script","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.475044Z","response":"'","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.504661Z","response":"s","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.534224Z","response":" em","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.564412Z","response":"brace","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.594516Z","response":"\n","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.62472Z","response":"C","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.654375Z","response":"atch","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.68401Z","response":"es","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.714081Z","response":" errors","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.743859Z","response":" in","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.774323Z","response":" bright","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.804104Z","response":" light","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.833915Z","response":"\n","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.864629Z","response":"Program","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.895629Z","response":"mer","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.925333Z","response":"'","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.955512Z","response":"s","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:15.985336Z","response":" bl","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:16.015224Z","response":"iss","done":false}
+{"model":"llama2","created_at":"2023-09-18T22:33:16.047292Z","done":true,"context":[29961,25580,29962,14350,263,447,18282,1048,5167,4081,29889,2538,2818,411,871,278,5952,18282,29901,518,29914,25580,29962,29871,18585,29991,2266,338,263,447,18282,1048,5167,4081,29901,13,13,1542,4081,29915,29879,953,13842,13,29907,905,267,4436,297,11785,3578,13,9283,1050,29915,29879,1999,790],"total_duration":6754466208,"load_duration":409934375,"prompt_eval_count":25,"prompt_eval_duration":5320331000,"eval_count":34,"eval_duration":989688000}
+

--- a/packages/models/tsup.config.ts
+++ b/packages/models/tsup.config.ts
@@ -44,6 +44,20 @@ export default defineConfig([
     dts: true,
   },
   {
+    entry: ['src/ollama/generation.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist/ollama',
+    external: [/^@axflow\/models\//],
+    dts: true,
+  },
+  {
+    entry: ['src/ollama/embedding.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist/ollama',
+    external: [/^@axflow\/models\//],
+    dts: true,
+  },
+  {
     entry: ['src/huggingface/text-generation.ts'],
     format: ['cjs', 'esm'],
     outDir: 'dist/huggingface',


### PR DESCRIPTION
https://ollama.ai is a very well packaged and easy to use solution to run LLM models locally on windows and mac. This PR adds support for using their completion endpoint & their embeddings endpoint.

These typically run locally.


## Testing
- [x] different models running locally after running `ollama serve`
   - [x] Unit tests
   - [x] Integration tests (not committed)  
- [x] Test through react hooks with axchat-demo