### PR TITLE
Add support for OpenAI functions in useChat hook

### DIFF
--- a/docs/documentation/models/shared.md
+++ b/docs/documentation/models/shared.md
@@ -231,16 +231,68 @@ type JSONValueType =
   | Array<JSONValueType>;
 ```
 
+## `FunctionType`
+
+If using OpenAI functions, this type corresponds to the functions passed to OpenAI as part of a request.
+
+See https://platform.openai.com/docs/api-reference/chat/create for more information.
+
+```ts
+type FunctionType = {
+  name: string;
+  description?: string;
+  parameters: JSONValueType;
+};
+```
+
 ## `MessageType`
 
 This is the type of each message in a chat, mostly used by the `useChat` hook.
 
 ```ts
 type MessageType = {
+  /**
+   * Can be any unique string.
+   *
+   * For example, the `useChat` hook uses UUIDs because of their native availability in both Node and browsers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
+   */
   id: string;
+  /**
+   * Specifies who this message is from.
+   */
   role: 'user' | 'assistant' | 'system';
-  data?: JSONValueType[];
+  /**
+   * The content of the message. If the message was a function call from the assistant,
+   * then this field will be an empty string and the `functionCall` field will be populated.
+   */
   content: string;
+  /**
+   * The time this message was created, expressed as milliseconds since Epoch.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+   */
   created: number;
+  /**
+   * Any additional data to associate with the message.
+   */
+  data?: JSONValueType[];
+  /**
+   * If using OpenAI functions, the functions available to the assistant can be defined here.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/create
+   */
+  functions?: FunctionType[];
+  /**
+   * If using OpenAI functions and the assistant responds with a function call,
+   * this field will be populated with the function invocation information.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/object
+   */
+  functionCall?: {
+    name: string;
+    arguments: string;
+  };
 };
 ```

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -6,10 +6,53 @@ export type JSONValueType =
   | { [x: string]: JSONValueType }
   | Array<JSONValueType>;
 
+export type FunctionType = { name: string; description?: string; parameters: JSONValueType };
+
 export type MessageType = {
+  /**
+   * Can be any unique string.
+   *
+   * For example, the `useChat` hook uses UUIDs because of their native availability in both Node and browsers.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID
+   */
   id: string;
+
+  /**
+   * Specifies who this message is from.
+   */
   role: 'user' | 'assistant' | 'system';
-  data?: JSONValueType[];
+
+  /**
+   * The content of the message. If the message was a function call from the assistant,
+   * then this field will be an empty string and the `functionCall` field will be populated.
+   */
   content: string;
+
+  /**
+   * The time this message was created, expressed as milliseconds since Epoch.
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+   */
   created: number;
+
+  /**
+   * Any additional data to associate with the message.
+   */
+  data?: JSONValueType[];
+
+  /**
+   * If using OpenAI functions, the functions available to the assistant can be defined here.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/create
+   */
+  functions?: FunctionType[];
+
+  /**
+   * If using OpenAI functions and the assistant responds with a function call,
+   * this field will be populated with the function invocation information.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/object
+   */
+  functionCall?: { name: string; arguments: string };
 };


### PR DESCRIPTION
This adds a `FunctionType`, updates `MessageType`, and adds the following to the React hook:

* functions
* setFunctions
* initialFunctions
* functionCallAccessor
