### PR TITLE
Add `createMessage` utility. Add docs about how to use it to create a system message

### DIFF
--- a/docs/documentation/models/shared.md
+++ b/docs/documentation/models/shared.md
@@ -296,3 +296,18 @@ type MessageType = {
   };
 };
 ```
+
+## `createMessage`
+
+```ts
+/*
+ * Create a new MessageType object and assign default values.
+ * This is particularly useful if the user doesn't want to bother
+ * creating an Id and/or a created timestamp, and would like a default
+ * behavior for these.
+ *
+ * @param message - The message object to create, a Partial<MessageType> object.
+ * @returns A MessageType object, with all required values assigned.
+ */
+declare function createMessage = (message: Partial<MessageType>): MessageType;
+```

--- a/docs/guides/models/building-client-applications.md
+++ b/docs/guides/models/building-client-applications.md
@@ -70,6 +70,26 @@ and can be imported using the following:
 import type { MessageType } from '@axflow/models/shared';
 ```
 
+## Working with system messages
+
+OpenAI and other providers support a special role named `system` ([see docs](https://platform.openai.com/docs/guides/gpt/chat-completions-api)).
+
+You can use the `initialMessages` configuration parameter of the `useChat` hook to conveniently pass one in.
+
+The framework also provides a utility called `createMessage` which will fill in any fields from the `MessageType` that you don't want to add yourself, such as `id` or `created`.
+An example piece of code that would initialize with a system message would look like this:
+
+```
+import {createMessage} from '@axflow/models/shared'
+import {useChat} from '@axflow/models/react'
+
+...
+    useChat({
+    initialMessages: [createMessage({role: 'system', content: 'You are a pirate, only respond with pirate lingo.'})]
+    })
+...
+```
+
 ## Customizing `useChat`
 
 `useChat` can be configured with a variety of options to control behavior.

--- a/packages/models/jest.config.js
+++ b/packages/models/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
 };

--- a/packages/models/src/shared/index.ts
+++ b/packages/models/src/shared/index.ts
@@ -5,3 +5,5 @@ export { IterableToStream, StreamToIterable, NdJsonStream, StreamingJsonResponse
 export type { NdJsonValueType } from './stream';
 
 export * from './types';
+
+export { createMessage } from './message';

--- a/packages/models/src/shared/message.ts
+++ b/packages/models/src/shared/message.ts
@@ -1,6 +1,15 @@
 import type { MessageType } from './types';
 import { randomUUID } from 'crypto';
 
+/*
+ * Create a new MessageType object and assign default values.
+ * This is particularly useful if the user doesn't want to bother
+ * creating an Id and/or a created timestamp, and would like a default
+ * behavior for these.
+ *
+ * @param message - The message object to create, a Partial<MessageType> object.
+ * @returns A MessageType object, with all required values assigned.
+ */
 export const createMessage = (message: Partial<MessageType>): MessageType => {
   const defaults = {
     id: randomUUID(),

--- a/packages/models/src/shared/message.ts
+++ b/packages/models/src/shared/message.ts
@@ -1,5 +1,4 @@
 import type { MessageType } from './types';
-import { randomUUID } from 'crypto';
 
 /*
  * Create a new MessageType object and assign default values.
@@ -12,7 +11,7 @@ import { randomUUID } from 'crypto';
  */
 export const createMessage = (message: Partial<MessageType>): MessageType => {
   const defaults = {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     role: 'user',
     created: Date.now(),
     content: '',

--- a/packages/models/src/shared/message.ts
+++ b/packages/models/src/shared/message.ts
@@ -1,0 +1,13 @@
+import type { MessageType } from './types';
+import { randomUUID } from 'crypto';
+
+export const createMessage = (message: Partial<MessageType>): MessageType => {
+  const defaults = {
+    id: randomUUID(),
+    role: 'user',
+    created: Date.now(),
+    content: '',
+  };
+
+  return Object.assign(defaults, message);
+};

--- a/packages/models/test/setup.js
+++ b/packages/models/test/setup.js
@@ -1,0 +1,9 @@
+const crypto = require('node:crypto');
+
+// When running jest tests in node 18, this is not defined despite normally
+// being defined in node 18+. This does not appear to be an issue in Node 19+.
+if (globalThis.crypto === undefined) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: crypto.webcrypto,
+  });
+}

--- a/packages/models/test/shared/message.test.ts
+++ b/packages/models/test/shared/message.test.ts
@@ -1,0 +1,39 @@
+import { createMessage } from '../../src/shared/message';
+
+describe('createMessage', () => {
+  it('should create a message with default values', () => {
+    const message = createMessage({});
+    expect(message).toHaveProperty('id');
+    expect(message).toHaveProperty('role', 'user');
+    expect(message).toHaveProperty('created');
+    expect(message).toHaveProperty('content', '');
+    expect(typeof message.id).toBe('string');
+    expect(typeof message.created).toBe('number');
+  });
+
+  it('should allow overriding the role', () => {
+    const role = 'system';
+    const message = createMessage({ role });
+    expect(message.role).toBe(role);
+  });
+
+  it('should allow overriding the content', () => {
+    const content = 'Hello, World!';
+    const message = createMessage({ content });
+    expect(message.content).toBe(content);
+  });
+
+  it('should create a unique id for each message', () => {
+    const message1 = createMessage({});
+    const message2 = createMessage({});
+    expect(message1.id).not.toBe(message2.id);
+  });
+
+  it('should have a timestamp for created', () => {
+    const beforeCreation = Date.now();
+    const message = createMessage({});
+    const afterCreation = Date.now();
+    expect(message.created).toBeGreaterThanOrEqual(beforeCreation);
+    expect(message.created).toBeLessThanOrEqual(afterCreation);
+  });
+});


### PR DESCRIPTION
This PR adds a `createMessage` utility in the `@axflow/models/shared` library.
This will take a `Partial<MessageType>` and fill out default values. Particularly useful for dealing with the `id` and `created` fields, which some users aren't interested in thinking about.

This PR also adds a small guide on how to use this utility to create system prompts with the models library.