### PR TITLE
Fix return types for openAI chunking when using tools

### DIFF
--- a/packages/models/src/openai/chat.ts
+++ b/packages/models/src/openai/chat.ts
@@ -75,7 +75,7 @@ export namespace OpenAIChatTypes {
     choices: Array<{
       index: number;
       delta: Delta;
-      finish_reason: 'stop' | 'length' | 'function_call' | null;
+      finish_reason: 'stop' | 'length' | 'function_call' | 'tool_calls' | null;
     }>;
   };
 
@@ -86,6 +86,12 @@ export namespace OpenAIChatTypes {
       name?: string;
       arguments?: string;
     };
+    tool_calls?: Array<{
+      index: number;
+      id?: string;
+      type?: 'function';
+      function: { name?: string; arguments: string };
+    }>;
   };
 }
 


### PR DESCRIPTION
OpenAI has changed their return type for chat chunks when passing tools. This was previously missed when upgrading the types.

[OpenAI docs](https://platform.openai.com/docs/api-reference/chat/streaming)

Example stream response with chunks when using tools (with multiple tools):
```
 {
        id: 'chatcmpl-8LOwr2AcOfQU0zPGdCKkyYIlnz30B',
        object: 'chat.completion.chunk',
        created: 1700111481,
        model: 'gpt-4-1106-preview',
        system_fingerprint: 'fp_a24b4d720c',
        choices: [
          {
            index: 0,
            delta: {
              tool_calls: [
                {
                  index: 1,
                  id: 'call_jhnWkqVN0F1vSHMoLkDGnKXr',
                  type: 'function',
                  function: { name: 'get_current_weather', arguments: '' }
                }
              ]
            },
            finish_reason: null
          }
        ]
      }

      at Object.<anonymous> (test/integration.gitignored.test.ts:94:15)

    console.dir
      {
        id: 'chatcmpl-8LOwr2AcOfQU0zPGdCKkyYIlnz30B',
        object: 'chat.completion.chunk',
        created: 1700111481,
        model: 'gpt-4-1106-preview',
        system_fingerprint: 'fp_a24b4d720c',
        choices: [
          {
            index: 0,
            delta: {
              tool_calls: [ { index: 1, function: { arguments: '{"lo' } } ]
            },
            finish_reason: null
          }
        ]
      }
```