### PR TITLE
Support the new tool_calls openAI spec, and add a toolCallAccessor to the react hooks

### DIFF
--- a/docs/documentation/models/react.md
+++ b/docs/documentation/models/react.md
@@ -53,8 +53,8 @@ interface ToolCallsAccessorType<T = any> {
   (value: T):
     | {
         index: number;
-        id?: string;
-        type?: 'function';
+        id: string;
+        type: 'function';
         function: { name?: string; arguments: string };
       }
     | null

--- a/docs/documentation/models/react.md
+++ b/docs/documentation/models/react.md
@@ -49,6 +49,18 @@ interface FunctionCallAccessorType<T = any> {
     | undefined;
 }
 
+interface ToolCallsAccessorType<T = any> {
+  (value: T):
+    | {
+        index: number;
+        id?: string;
+        type?: 'function';
+        function: { name?: string; arguments: string };
+      }
+    | null
+    | undefined;
+}
+
 type BodyType =
   | Record<string, JSONValueType>
   | ((message: MessageType, history: MessageType[]) => JSONValueType);
@@ -137,6 +149,35 @@ type UseChatOptionsType = {
    *     });
    */
   functionCallAccessor?: FunctionCallAccessorType;
+
+  /**
+   * An accessor used to pluck out multiple tool calls for LLMs that support it.
+   * This is the new nomenclature for openAI's functions, since they now can return
+   * multiple in one call.
+   *
+   * This is used to return the object which will then be populated
+   * on the assistant message's `tool_calls` property. A tool_call object
+   * consists of a index, id, type (always 'function') and function object
+   * with name and parameters, encoded as JSON like for the functionCall above.
+   *
+   * For example, if this hook is used to stream an OpenAI-compatible API response
+   * using openAI tools, the following options can be defined to interpret the response:
+   *
+   *     import { useChat } from '@axflow/models/react';
+   *     import type { OpenAIChatTypes } from '@axflow/models/openai/chat';
+   *
+   *     const { ... } = useChat({
+   *       accessor: (value: OpenAIChatTypes.Chunk) => {
+   *         return value.choices[0].delta.content;
+   *       },
+   *
+   *       toolCallsAccessor: (value: OpenAIChatTypes.Chunk) => {
+   *         return value.choices[0].delta.tool_calls;
+   *       }
+   *     });
+   */
+  toolCallsAccessor?: ToolCallsAccessorType;
+
   /**
    * Initial message input. Defaults to empty string.
    */
@@ -158,6 +199,16 @@ type UseChatOptionsType = {
    *
    * Defaults to `console.error`.
    */
+
+  /**
+   * Initial seet of available tools, which replaced functions, for the user's
+   * next message.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/create
+   *
+   */
+  initialTools?: ToolType[];
+
   onError?: (error: Error) => void;
   /**
    * Callback that is invoked when the list of messages change.
@@ -229,6 +280,16 @@ type UseChatResultType = {
    * first sent until the stream has closed. For non-streaming requests, it is `true`
    * until a response is received.
    */
+
+  /**
+   * Update list of tools for the next user message.
+   *
+   * This is primarily intended for OpenAI's tools feature.
+   *
+   * @see https://platform.openai.com/docs/api-reference/chat/create
+   */
+  setTools: (tools: ToolType[]) => void;
+
   loading: boolean;
   /**
    * If a request fails, this will be populated with the `Error`. This will be reset

--- a/docs/documentation/models/react.md
+++ b/docs/documentation/models/react.md
@@ -52,10 +52,10 @@ interface FunctionCallAccessorType<T = any> {
 interface ToolCallsAccessorType<T = any> {
   (value: T):
     | {
-        index: number;
-        id: string;
-        type: 'function';
-        function: { name?: string; arguments: string };
+        index?: number;
+        id?: string;
+        type?: 'function';
+        function?: { name?: string; arguments: string };
       }
     | null
     | undefined;

--- a/docs/documentation/models/shared.md
+++ b/docs/documentation/models/shared.md
@@ -245,6 +245,32 @@ type FunctionType = {
 };
 ```
 
+## `ToolType`
+
+Tools have replaced functions in openAI's nomenclature. Functions are now a type of tools,
+and each LLM response can contain multiple tool calls.
+
+```ts
+type ToolType = {
+  type: 'function';
+  function: FunctionType;
+};
+```
+
+## `ToolCallType`
+
+When the LLM decides to call a tool (previously named a function), this is
+the type that we send down to the client.
+
+```ts
+type ToolCallType = {
+  index: number;
+  id?: string;
+  type?: 'function';
+  function: { name?: string; arguments: string };
+};
+```
+
 ## `MessageType`
 
 This is the type of each message in a chat, mostly used by the `useChat` hook.
@@ -294,6 +320,20 @@ type MessageType = {
     name: string;
     arguments: string;
   };
+  /**
+   * If using openAI tools, the tools available to the assistant can be defined here.
+   *
+   * @see  https://platform.openai.com/docs/guides/function-calling
+   */
+  tools?: ToolType[];
+  /**
+   * If using OpenAI tools and the assistant responds with one or more tool calls,
+   * this field will be populated with the tool invocation information.
+   *
+   *
+   * @see https://platform.openai.com/docs/guides/function-calling
+   */
+  toolCalls?: ToolCallType[];
 };
 ```
 

--- a/docs/documentation/models/shared.md
+++ b/docs/documentation/models/shared.md
@@ -265,9 +265,9 @@ the type that we send down to the client.
 ```ts
 type ToolCallType = {
   index: number;
-  id?: string;
-  type?: 'function';
-  function: { name?: string; arguments: string };
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
 };
 ```
 

--- a/packages/models/src/shared/index.ts
+++ b/packages/models/src/shared/index.ts
@@ -7,3 +7,5 @@ export type { NdJsonValueType } from './stream';
 export * from './types';
 
 export { createMessage } from './message';
+
+export * from './utils';

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -9,10 +9,18 @@ export type JSONValueType =
 export type FunctionType = { name: string; description?: string; parameters: JSONValueType };
 
 /*
- * This is the openAI tool type
+ * The spec of a tool that the client sends up to the LLM server.
+ *
+ * @see https://platform.openai.com/docs/guides/function-calling
  */
 export type ToolType = { type: 'function'; function: FunctionType };
 
+/*
+ * When the LLM decides to call a tool (previously named a function), this is
+ * the type that we send down to the client.
+ *
+ * @see https://platform.openai.com/docs/api-reference/chat/streaming
+ */
 export type ToolCallType = {
   index: number;
   id?: string;

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -1,3 +1,5 @@
+import type { RecursivePartial } from './utils';
+
 export type JSONValueType =
   | null
   | string
@@ -27,6 +29,16 @@ export type ToolCallType = {
   type: 'function';
   function: { name: string; arguments: string };
 };
+
+export const toolCallWithDefaults = (toolCall: RecursivePartial<ToolCallType>): ToolCallType => ({
+  index: toolCall.index ?? 0,
+  id: toolCall.id ?? '',
+  type: 'function',
+  function: {
+    name: toolCall.function?.name ?? '',
+    arguments: toolCall.function?.arguments ?? '',
+  },
+});
 
 export type MessageType = {
   /**

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -77,17 +77,18 @@ export type MessageType = {
   functionCall?: { name: string; arguments: string };
 
   /**
-   * TODO
+   * If using openAI tools, the tools available to the assistant can be defined here.
+   *
+   * @see  https://platform.openai.com/docs/guides/function-calling
    */
   tools?: ToolType[];
 
   /**
-   * TODO
+   * If using OpenAI tools and the assistant responds with one or more tool calls,
+   * this field will be populated with the tool invocation information.
+   *
+   *
+   * @see https://platform.openai.com/docs/guides/function-calling
    */
-  toolCalls?: {
-    index: number;
-    id?: string;
-    type?: 'function';
-    function: { name?: string; arguments: string };
-  }[];
+  toolCalls?: ToolCallType[];
 };

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -8,6 +8,18 @@ export type JSONValueType =
 
 export type FunctionType = { name: string; description?: string; parameters: JSONValueType };
 
+/*
+ * This is the openAI tool type
+ */
+export type ToolType = { type: 'function'; function: FunctionType };
+
+export type ToolCallType = {
+  index: number;
+  id?: string;
+  type?: 'function';
+  function: { name?: string; arguments: string };
+};
+
 export type MessageType = {
   /**
    * Can be any unique string.
@@ -55,4 +67,19 @@ export type MessageType = {
    * @see https://platform.openai.com/docs/api-reference/chat/object
    */
   functionCall?: { name: string; arguments: string };
+
+  /**
+   * TODO
+   */
+  tools?: ToolType[];
+
+  /**
+   * TODO
+   */
+  toolCalls?: {
+    index: number;
+    id?: string;
+    type?: 'function';
+    function: { name?: string; arguments: string };
+  }[];
 };

--- a/packages/models/src/shared/types.ts
+++ b/packages/models/src/shared/types.ts
@@ -23,9 +23,9 @@ export type ToolType = { type: 'function'; function: FunctionType };
  */
 export type ToolCallType = {
   index: number;
-  id?: string;
-  type?: 'function';
-  function: { name?: string; arguments: string };
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
 };
 
 export type MessageType = {

--- a/packages/models/src/shared/utils.ts
+++ b/packages/models/src/shared/utils.ts
@@ -1,0 +1,7 @@
+export type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object | undefined
+    ? RecursivePartial<T[P]>
+    : T[P];
+};


### PR DESCRIPTION
Fixes https://github.com/axflow/axflow/issues/100

This PR introduces support for the new `tools` spec by openAI. OpenAI functions can now return multiple function calls in one response, and they've renamed their nomenclature to a higher level concept named 'Tool'. Now,  a `Function` is a type of `Tool`.

This PR introduces support at the react hook level of a new `toolCallsAccessor` configuration mechanism, which works both when streaming and when calling the JSON API directly.

We still support the `function` behavior, as it is still live and some people might still rely on it. They are compatible. 