### PR TITLE
Add Together.ai inference endpoint

### DIFF
--- a/docs/documentation/models.md
+++ b/docs/documentation/models.md
@@ -8,6 +8,7 @@ npm i @axflow/models
 
 ## Features
 
+- Support for all leading model providers, plus popular open source models like Llama2 or Mistral through Together.ai inference
 - First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
 - First-class support for streaming arbitrary data in addition to the LLM response
 - Comes with a set of utilities and React hooks for easily creating robust client applications
@@ -23,6 +24,7 @@ npm i @axflow/models
 - ✅ HuggingFace text generation inference API and Inference Endpoints
 - ✅ Ollama.ai models running generation or embedding generation
 - ✅ Azure OpenAI
+- ✅ TogetherAI (Llama2, Mistral, etc.)
 - Google PaLM models (coming soon)
 - Replicate (coming soon)
 
@@ -40,6 +42,7 @@ View the [Guides](/guides) or the reference:
 - [@axflow/models/huggingface/text-generation](/documentation/models/huggingface-text-generation)
 - [@axflow/models/ollama/generation](/documentation/models/ollama-generation)
 - [@axflow/models/ollama/embedding](/documentation/models/ollama-embedding)
+- [@axflow/models/togetherai/inference](/documentation/models/togetherai-inference)
 - [@axflow/models/react](/documentation/models/react)
 - [@axflow/models/node](/documentation/models/node)
 - [@axflow/models/shared](/documentation/models/shared)

--- a/docs/documentation/models/togetherai-inference.md
+++ b/docs/documentation/models/togetherai-inference.md
@@ -1,0 +1,109 @@
+# @axflow/models/togetherai/inference
+
+Interface with [TogetherAI's Inference API](https://docs.together.ai/reference/inference) using this module.
+
+```ts
+import { TogetherAIInference } from '@axflow/models/togetherai/inference';
+import type { TogetherAIInferenceTypes } from '@axflow/models/togetherai/inference';
+```
+
+```ts
+declare class TogetherAIInference {
+  static run: typeof run;
+  static stream: typeof stream;
+  static streamBytes: typeof streamBytes;
+  static streamTokens: typeof streamTokens;
+}
+```
+
+## `run`
+
+```ts
+/**
+ * Run a prediction request against TogetherAI's inference API.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns TogetherAI inference response. See https://docs.together.ai/reference/inference.
+ */
+declare function run(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions
+): Promise<TogetherAIInferenceTypes.Response>;
+```
+
+## `streamBytes`
+
+```ts
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream is the raw unmodified bytes from the API.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of bytes directly from the API.
+ */
+declare function streamBytes(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions
+): Promise<ReadableStream<Uint8Array>>;
+```
+
+## `stream`
+
+```ts
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream is the parsed stream data as JavaScript objects.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of objects representing each chunk from the API.
+ */
+declare function stream(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions
+): Promise<ReadableStream<TogetherAIInferenceTypes.Chunk>>;
+```
+
+## `streamTokens`
+
+```ts
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream emits only the string tokens.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of tokens from the API.
+ */
+declare function streamTokens(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions
+): Promise<ReadableStream<string>>;
+```

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -8,6 +8,7 @@ npm i @axflow/models
 
 ## Features
 
+- Support for all leading model providers, plus popular open source models like Llama2 or Mistral through Together.ai inference
 - First-class streaming support for both low-level byte streams and higher-level JavaScript object streams
 - First-class support for streaming arbitrary data in addition to the LLM response
 - Comes with a set of utilities and React hooks for easily creating robust client applications
@@ -23,6 +24,7 @@ npm i @axflow/models
 - ✅ HuggingFace text generation inference API and Inference Endpoints
 - ✅ Ollama.ai models running locally
 - ✅ Azure OpenAI
+- ✅ TogetherAI (Llama2, Mistral, etc.)
 - Google PaLM models (coming soon)
 - Replicate (coming soon)
 
@@ -40,6 +42,7 @@ View the [Guides](https://docs.axflow.dev/guides) or the reference:
 - [@axflow/models/huggingface/text-generation](https://docs.axflow.dev/documentation/models/huggingface-text-generation.html)
 - [@axflow/models/ollama/generation](https://docs.axflow.dev/documentation/models/ollama-generation.html)
 - [@axflow/models/ollama/embedding](https://docs.axflow.dev/documentation/models/ollama-embedding.html)
+- [@axflow/models/togetherai/inference](https://docs.axflow.dev/documentation/models/togetherai-inference.html)
 - [@axflow/models/react](https://docs.axflow.dev/documentation/models/react.html)
 - [@axflow/models/node](https://docs.axflow.dev/documentation/models/node.html)
 - [@axflow/models/shared](https://docs.axflow.dev/documentation/models/shared.html)

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -110,6 +110,9 @@
       "huggingface": [
         "./dist/huggingface/index.d.ts"
       ],
+      "togetherai": [
+        "./dist/togetherai/inference.d.ts"
+      ],
       "shared": [
         "./dist/shared/index.d.ts"
       ]
@@ -176,6 +179,12 @@
       "import": "./dist/huggingface/text-generation.mjs",
       "module": "./dist/huggingface/text-generation.mjs",
       "require": "./dist/huggingface/text-generation.js"
+    },
+    "./togetherai/inference": {
+      "types": "./dist/togetherai/inference.d.ts",
+      "import": "./dist/togetherai/inference.mjs",
+      "module": "./dist/togetherai/inference.mjs",
+      "require": "./dist/togetherai/inference.js"
     },
     "./react": {
       "types": "./dist/react/index.d.ts",

--- a/packages/models/src/togetherai/inference.ts
+++ b/packages/models/src/togetherai/inference.ts
@@ -1,0 +1,280 @@
+import { HttpError, POST } from '@axflow/models/shared';
+
+const TOGETHERAI_INFERENCE_ENDPOINT = 'https://api.together.xyz/inference';
+
+export namespace TogetherAIInferenceTypes {
+  export type RequestOptions = {
+    apiKey?: string;
+    apiUrl?: string;
+    fetch?: typeof fetch;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+  };
+
+  export type Request = {
+    model: string;
+    prompt: string;
+    max_tokens: number;
+    stop?: string[];
+    temperature?: number;
+    top_p?: number;
+    top_k?: number;
+    repetition_penalty?: number;
+    logprobs?: number;
+    safety_model?: string;
+  };
+
+  export type Response = {
+    id: string;
+    status: string;
+    prompt: string[];
+    model: string;
+    model_owner: string;
+    tags?: Record<string, any>;
+    num_returns: number;
+    args: {
+      model: string;
+      prompt: string;
+      max_tokens: number;
+      stream: boolean;
+      temperature?: number;
+      top_p?: number;
+      top_k?: number;
+    };
+    subjobs: any[];
+    output: {
+      usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+      };
+      result_type: string;
+      raw_compute_time?: number;
+      choices: Array<{
+        text: string;
+        index?: number;
+        finish_reason?: string;
+      }>;
+    };
+  };
+
+  export type Chunk = {
+    id: string;
+    choices: Array<{
+      text: string;
+    }>;
+    generated_text?: string;
+    token: { id: number; text: string; logprob: number; special: boolean };
+    stats: null | {
+      total_time: { secs: number; nanos: number };
+      validation_time: { secs: number; nanos: number };
+      queue_time: { secs: number; nanos: number };
+      inference_time: { secs: number; nanos: number };
+      time_per_token: { secs: number; nanos: number };
+    };
+    usage: null | {
+      prompt_tokens: number;
+      completion_tokens: number;
+      total_tokens: number;
+    };
+  };
+}
+
+function headers(apiKey?: string, customHeaders?: Record<string, string>) {
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+    ...customHeaders,
+  };
+
+  if (typeof apiKey === 'string') {
+    headers.authorization = `Bearer ${apiKey}`;
+  }
+
+  return headers;
+}
+
+/**
+ * Run a prediction request against TogetherAI's inference API.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns TogetherAI inference response. See https://docs.together.ai/reference/inference.
+ */
+async function run(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions,
+): Promise<TogetherAIInferenceTypes.Response> {
+  const url = options.apiUrl || TOGETHERAI_INFERENCE_ENDPOINT;
+
+  const response = await POST(url, {
+    headers: headers(options.apiKey, options.headers),
+    body: JSON.stringify({ ...request, stream_tokens: false }),
+    fetch: options.fetch,
+    signal: options.signal,
+  });
+
+  return response.json();
+}
+
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream is the raw unmodified bytes from the API.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of bytes directly from the API.
+ */
+async function streamBytes(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions,
+): Promise<ReadableStream<Uint8Array>> {
+  const url = options.apiUrl || TOGETHERAI_INFERENCE_ENDPOINT;
+
+  const response = await POST(url, {
+    headers: headers(options.apiKey, options.headers),
+    body: JSON.stringify({ ...request, stream_tokens: true }),
+    fetch: options.fetch,
+    signal: options.signal,
+  });
+
+  if (!response.body) {
+    throw new HttpError('Expected response body to be a ReadableStream', response);
+  }
+
+  return response.body;
+}
+
+function noop(chunk: TogetherAIInferenceTypes.Chunk) {
+  return chunk;
+}
+
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream is the parsed stream data as JavaScript objects.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of objects representing each chunk from the API.
+ */
+async function stream(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions,
+): Promise<ReadableStream<TogetherAIInferenceTypes.Chunk>> {
+  const byteStream = await streamBytes(request, options);
+  return byteStream.pipeThrough(new TogetherAIInferenceDecoderStream(noop));
+}
+
+function chunkToToken(chunk: TogetherAIInferenceTypes.Chunk) {
+  return chunk.choices[0].text || '';
+}
+
+/**
+ * Run a streaming prediction request against TogetherAI's inference API. The resulting stream emits only the string tokens.
+ *
+ * @see https://docs.together.ai/reference/inference
+ *
+ * @param request The request body sent to TogetherAI. See https://docs.together.ai/reference/inference.
+ * @param options
+ * @param options.apiKey TogetherAI API key.
+ * @param options.apiUrl The url of the TogetherAI (or compatible) API. Defaults to https://api.together.xyz/inference.
+ * @param options.fetch A custom implementation of fetch. Defaults to globalThis.fetch.
+ * @param options.headers Optionally add additional HTTP headers to the request.
+ * @param options.signal An AbortSignal that can be used to abort the fetch request.
+ * @returns A stream of tokens from the API.
+ */
+async function streamTokens(
+  request: TogetherAIInferenceTypes.Request,
+  options: TogetherAIInferenceTypes.RequestOptions,
+): Promise<ReadableStream<string>> {
+  const byteStream = await streamBytes(request, options);
+  return byteStream.pipeThrough(new TogetherAIInferenceDecoderStream(chunkToToken));
+}
+
+/**
+ * An object that encapsulates methods for calling the TogetherAI inference API.
+ */
+export class TogetherAIInference {
+  static run = run;
+  static stream = stream;
+  static streamBytes = streamBytes;
+  static streamTokens = streamTokens;
+}
+
+class TogetherAIInferenceDecoderStream<T> extends TransformStream<Uint8Array, T> {
+  static DATA_RE = /data:\s*(.+)/;
+
+  static parseChunk<T>(chunk: string): T | null {
+    chunk = chunk.trim();
+
+    if (chunk.length === 0) {
+      return null;
+    }
+
+    const match = chunk.match(TogetherAIInferenceDecoderStream.DATA_RE);
+
+    try {
+      const data = match![1];
+      return data === '[DONE]' ? null : JSON.parse(data);
+    } catch (error) {
+      throw new Error(
+        `Encountered unexpected chunk while parsing TogetherAI streaming response: ${JSON.stringify(
+          chunk,
+        )}`,
+      );
+    }
+  }
+
+  static streamTransformer<InputChunk, OutputChunk>(map: (chunk: InputChunk) => OutputChunk) {
+    let buffer: string[] = [];
+    const decoder = new TextDecoder();
+
+    return (bytes: Uint8Array, controller: TransformStreamDefaultController<OutputChunk>) => {
+      const chunk = decoder.decode(bytes);
+
+      for (let i = 0, len = chunk.length; i < len; ++i) {
+        // Events separated by '\n\n'
+        const isChunkSeparator = chunk[i] === '\n' && buffer[buffer.length - 1] === '\n';
+
+        // Keep buffering unless we've hit the end of a data chunk
+        if (!isChunkSeparator) {
+          buffer.push(chunk[i]);
+          continue;
+        }
+
+        const parsedChunk = TogetherAIInferenceDecoderStream.parseChunk<InputChunk>(
+          buffer.join(''),
+        );
+
+        if (parsedChunk) {
+          controller.enqueue(map(parsedChunk));
+        }
+
+        buffer = [];
+      }
+    };
+  }
+
+  constructor(map: (chunk: TogetherAIInferenceTypes.Chunk) => T) {
+    super({ transform: TogetherAIInferenceDecoderStream.streamTransformer(map) });
+  }
+}

--- a/packages/models/test/togetherai/inference.test.ts
+++ b/packages/models/test/togetherai/inference.test.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs/promises';
+import Path from 'node:path';
+
+import { createFakeFetch, createUnpredictableByteStream } from '../utils';
+import { TogetherAIInference } from '../../src/togetherai/inference';
+import { StreamToIterable } from '../../src/shared';
+
+describe('togetherai inference', () => {
+  let streamingInferenceResponse: string;
+
+  beforeAll(async () => {
+    streamingInferenceResponse = await fs.readFile(
+      Path.join(__dirname, 'streaming-inference-response.txt'),
+      {
+        encoding: 'utf8',
+      },
+    );
+  });
+
+  describe('run', () => {
+    it('executes a chat completion', async () => {
+      const fetchSpy = createFakeFetch({
+        json: {
+          id: '835be4714e021739-SJC',
+          status: 'finished',
+          prompt: ['[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] '],
+          model: 'togethercomputer/llama-2-70b-chat',
+          model_owner: '',
+          num_returns: 1,
+          args: {
+            model: 'togethercomputer/llama-2-70b-chat',
+            prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+            max_tokens: 250,
+            stream_tokens: false,
+          },
+          subjobs: [],
+          output: {
+            usage: {
+              prompt_tokens: 26,
+              completion_tokens: 30,
+              total_tokens: 56,
+            },
+            result_type: 'language-model-inference',
+            choices: [
+              {
+                text: "The Eiffel Tower is a famous iron lattice tower in Paris, France, built for the 1889 World's Fair.",
+              },
+            ],
+          },
+        },
+      });
+
+      const response = await TogetherAIInference.run(
+        {
+          model: 'togethercomputer/llama-2-70b-chat',
+          prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+          max_tokens: 250,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      expect(response.output.choices[0]).toEqual({
+        text: "The Eiffel Tower is a famous iron lattice tower in Paris, France, built for the 1889 World's Fair.",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.together.xyz/inference', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+        },
+      });
+
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({
+        model: 'togethercomputer/llama-2-70b-chat',
+        prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+        max_tokens: 250,
+        stream_tokens: false,
+      });
+    });
+  });
+
+  describe('stream', () => {
+    it('executes a streaming chat completion', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingInferenceResponse),
+      });
+
+      const response = await TogetherAIInference.stream(
+        {
+          model: 'togethercomputer/llama-2-70b-chat',
+          prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+          max_tokens: 250,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const chunk of StreamToIterable(response)) {
+        if (chunk.choices[0].text === '</s>') {
+          continue;
+        }
+
+        resultingText += chunk.choices[0].text;
+      }
+
+      expect(resultingText).toEqual(
+        " The Eiffel Tower is a famous iron lattice tower in Paris, France, built for the 1889 World's Fair.",
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.together.xyz/inference', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+        },
+      });
+
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({
+        model: 'togethercomputer/llama-2-70b-chat',
+        prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+        max_tokens: 250,
+        stream_tokens: true,
+      });
+    });
+  });
+
+  describe('streamTokens', () => {
+    it('streams only the tokens', async () => {
+      const fetchSpy = createFakeFetch({
+        body: createUnpredictableByteStream(streamingInferenceResponse),
+      });
+
+      const response = await TogetherAIInference.streamTokens(
+        {
+          model: 'togethercomputer/llama-2-70b-chat',
+          prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+          max_tokens: 250,
+        },
+        { apiKey: 'sk-not-real', fetch: fetchSpy as any },
+      );
+
+      let resultingText = '';
+
+      for await (const token of StreamToIterable(response)) {
+        if (token === '</s>') {
+          continue;
+        }
+
+        resultingText += token;
+      }
+
+      expect(resultingText).toEqual(
+        " The Eiffel Tower is a famous iron lattice tower in Paris, France, built for the 1889 World's Fair.",
+      );
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.together.xyz/inference', {
+        body: expect.any(String),
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer sk-not-real',
+          'content-type': 'application/json',
+        },
+      });
+
+      const args = fetchSpy.mock.lastCall as any;
+      const bodyArgument = JSON.parse(args[1].body);
+
+      expect(bodyArgument).toEqual({
+        model: 'togethercomputer/llama-2-70b-chat',
+        prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
+        max_tokens: 250,
+        stream_tokens: true,
+      });
+    });
+  });
+});

--- a/packages/models/test/togetherai/streaming-inference-response.txt
+++ b/packages/models/test/togetherai/streaming-inference-response.txt
@@ -1,0 +1,62 @@
+data: {"choices":[{"text":" The"}],"id":"83620a7a3857ceaf-SJC","token":{"id":450,"text":" The","logprob":-0.00016653538,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" E"}],"id":"83620a7a3857ceaf-SJC","token":{"id":382,"text":" E","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"iff"}],"id":"83620a7a3857ceaf-SJC","token":{"id":2593,"text":"iff","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"el"}],"id":"83620a7a3857ceaf-SJC","token":{"id":295,"text":"el","logprob":-0.0000011920929,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" Tower"}],"id":"83620a7a3857ceaf-SJC","token":{"id":23615,"text":" Tower","logprob":-0.000079631805,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" is"}],"id":"83620a7a3857ceaf-SJC","token":{"id":338,"text":" is","logprob":-0.0000026226044,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" a"}],"id":"83620a7a3857ceaf-SJC","token":{"id":263,"text":" a","logprob":-0.46240234,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" famous"}],"id":"83620a7a3857ceaf-SJC","token":{"id":13834,"text":" famous","logprob":-0.16662598,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" iron"}],"id":"83620a7a3857ceaf-SJC","token":{"id":13977,"text":" iron","logprob":-0.0014076233,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" lattice"}],"id":"83620a7a3857ceaf-SJC","token":{"id":24094,"text":" lattice","logprob":-0.003484726,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" tower"}],"id":"83620a7a3857ceaf-SJC","token":{"id":19372,"text":" tower","logprob":-0.0000692606,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" in"}],"id":"83620a7a3857ceaf-SJC","token":{"id":297,"text":" in","logprob":-0.000021576881,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" Paris"}],"id":"83620a7a3857ceaf-SJC","token":{"id":3681,"text":" Paris","logprob":-1.1920929e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":","}],"id":"83620a7a3857ceaf-SJC","token":{"id":29892,"text":",","logprob":-0.0000029802322,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" France"}],"id":"83620a7a3857ceaf-SJC","token":{"id":3444,"text":" France","logprob":-0.0007548332,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":","}],"id":"83620a7a3857ceaf-SJC","token":{"id":29892,"text":",","logprob":-0.5292969,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" built"}],"id":"83620a7a3857ceaf-SJC","token":{"id":4240,"text":" built","logprob":-0.013687134,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" for"}],"id":"83620a7a3857ceaf-SJC","token":{"id":363,"text":" for","logprob":-0.000008940697,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" the"}],"id":"83620a7a3857ceaf-SJC","token":{"id":278,"text":" the","logprob":-4.7683716e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" "}],"id":"83620a7a3857ceaf-SJC","token":{"id":29871,"text":" ","logprob":-0.004917145,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"1"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29896,"text":"1","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"8"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29947,"text":"8","logprob":-7.1525574e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"8"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29947,"text":"8","logprob":-4.7683716e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"9"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29929,"text":"9","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" World"}],"id":"83620a7a3857ceaf-SJC","token":{"id":2787,"text":" World","logprob":-0.0000038146973,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"'"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29915,"text":"'","logprob":-0.0000076293945,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"s"}],"id":"83620a7a3857ceaf-SJC","token":{"id":29879,"text":"s","logprob":-1.1920929e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":" Fair"}],"id":"83620a7a3857ceaf-SJC","token":{"id":13822,"text":" Fair","logprob":-5.9604645e-7,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"."}],"id":"83620a7a3857ceaf-SJC","token":{"id":29889,"text":".","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null,"usage":null}
+
+data: {"choices":[{"text":"</s>"}],"id":"83620a7a3857ceaf-SJC","token":{"id":2,"text":"</s>","logprob":-0.0000017881393,"special":true},"generated_text":"The Eiffel Tower is a famous iron lattice tower in Paris, France, built for the 1889 World's Fair.","details":null,"stats":{"total_time":{"secs":0,"nanos":592067479},"validation_time":{"secs":0,"nanos":488056},"queue_time":{"secs":0,"nanos":13699356},"inference_time":{"secs":0,"nanos":577880370},"time_per_token":{"secs":0,"nanos":19262679}},"usage":{"prompt_tokens":26,"completion_tokens":30,"total_tokens":56}}
+
+data: [DONE]
+

--- a/packages/models/tsup.config.ts
+++ b/packages/models/tsup.config.ts
@@ -72,6 +72,13 @@ export default defineConfig([
     dts: true,
   },
   {
+    entry: ['src/togetherai/inference.ts'],
+    format: ['cjs', 'esm'],
+    outDir: 'dist/togetherai',
+    external: [/^@axflow\/models\//],
+    dts: true,
+  },
+  {
     entry: ['src/react/index.ts'],
     format: ['cjs', 'esm'],
     outDir: 'dist/react',


### PR DESCRIPTION
For example, we can run Llama2 70B with:

```ts
import { StreamToIterable } from '@axflow/models/shared';
import { TogetherAIInference } from '@axflow/models/togetherai/inference';

const stream = await TogetherAIInference.stream(
  {
    model: 'togethercomputer/llama-2-70b-chat',
    prompt: '[INST] Using no more than 20 words, what is the Eiffel tower? [/INST] ',
    max_tokens: 250,
  },
  {
    apiKey: process.env.TOGETHERAI_API_KEY,
  }
);

for await (const chunk of StreamToIterable(stream)) {
  console.log(chunk);
}
```